### PR TITLE
Added SQLite database folder to data directory.

### DIFF
--- a/wazuh/config/data_dirs.env
+++ b/wazuh/config/data_dirs.env
@@ -4,4 +4,5 @@ DATA_DIRS[((i++))]="ruleset"
 DATA_DIRS[((i++))]="logs"
 DATA_DIRS[((i++))]="stats"
 DATA_DIRS[((i++))]="queue"
+DATA_DIRS[((i++))]="var/db"
 export DATA_DIRS

--- a/wazuh/config/init.bash
+++ b/wazuh/config/init.bash
@@ -8,5 +8,5 @@ source /data_dirs.env
 cd /var/ossec
 for ossecdir in "${DATA_DIRS[@]}"; do
   mv ${ossecdir} ${ossecdir}-template
-  ln -s data/${ossecdir} ${ossecdir}
+  ln -s $(realpath --relative-to=$(dirname ${ossecdir}) data)/${ossecdir} ${ossecdir}
 done

--- a/wazuh/config/run.sh
+++ b/wazuh/config/run.sh
@@ -19,6 +19,7 @@ for ossecdir in "${DATA_DIRS[@]}"; do
   if [ ! -e "${DATA_PATH}/${ossecdir}" ]
   then
     echo "Installing ${ossecdir}"
+    mkdir -p $(dirname ${DATA_PATH}/${ossecdir})
     cp -pr /var/ossec/${ossecdir}-template ${DATA_PATH}/${ossecdir}
     FIRST_TIME_INSTALLATION=true
   fi


### PR DESCRIPTION
Folder `/var/ossec/var/db` contains the new SQLite databases and they are synced by the new Wazuh module.

Since they are never copied onto the data mount volume and the it would be created every time that containers are created.

This commit will create and link the `var/db` folder in the same way as the others. There are a pair of new commands to create the symbolic link with relative paths and to make the new parent folders.