### PR TITLE
Missing config filename causes logstash to not start.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: wazuh/wazuh-logstash
     hostname: logstash
     restart: always
-    command: -f /etc/logstash/conf.d/logstatsh.conf
+    command: -f /etc/logstash/conf.d/logstash.conf
 #    volumes:
 #      - ./logstash/config:/etc/logstash/conf.d
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: wazuh/wazuh-logstash
     hostname: logstash
     restart: always
-    command: -f /etc/logstash/conf.d/logstash.conf
+    command: -f /etc/logstash/conf.d/*.conf
 #    volumes:
 #      - ./logstash/config:/etc/logstash/conf.d
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     image: wazuh/wazuh-logstash
     hostname: logstash
     restart: always
-    command: -f /etc/logstash/conf.d/
+    command: -f /etc/logstash/conf.d/logstatsh.conf
 #    volumes:
 #      - ./logstash/config:/etc/logstash/conf.d
     links:


### PR DESCRIPTION
In the docker-compose.yml the name of the config file for the -f options passed to logstash is missing causing it to not find the file and therefore crashing with an error.