### PR TITLE
Configurable URL for kibana plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,8 @@ services:
     depends_on:
       - elasticsearch
     entrypoint: sh wait-for-it.sh elasticsearch
+#    environment:
+#      - "WAZUH_KIBANA_PLUGIN_URL=http://your.repo/wazuhapp-2.0_5.3.0.zip"
 
 networks:
   docker_elk:

--- a/kibana/config/wait-for-it.sh
+++ b/kibana/config/wait-for-it.sh
@@ -5,6 +5,7 @@ set -e
 host="$1"
 shift
 cmd="kibana"
+WAZUH_KIBANA_PLUGIN_URL=${WAZUH_KIBANA_PLUGIN_URL:-https://packages.wazuh.com/wazuhapp/wazuhapp-2.0_5.3.0.zip}
 
 until curl -XGET $host:9200; do
   >&2 echo "Elastic is unavailable - sleeping"
@@ -18,7 +19,7 @@ sleep 30
 if /usr/share/kibana/bin/kibana-plugin list | grep wazuh; then
   echo "Wazuh APP already installed"
 else
-  /usr/share/kibana/bin/kibana-plugin install https://packages.wazuh.com/wazuhapp/wazuhapp-2.0_5.3.0.zip
+  /usr/share/kibana/bin/kibana-plugin install ${WAZUH_KIBANA_PLUGIN_URL}
 fi
 
 exec $cmd


### PR DESCRIPTION
Added WAZUH_KIBANA_PLUGIN_URL variable to wait-for-it.sh so that kibana plugin installation URL can be overwritten (the default still points to https://packages.wazuh.com/wazuhapp/wazuhapp-2.0_5.3.0.zip).
This is useful in (most likely corporate) environments where there is no egress to the internet or users just prefer to mirror all software locally.

Could also be useful to test a different version of the plugin.