### PR TITLE
Automatic password generation for wazuh API

### DIFF
--- a/wazuh/config/init.bash
+++ b/wazuh/config/init.bash
@@ -5,6 +5,12 @@
 #
 source /data_dirs.env
 
+API_USER="wazadmin"
+API_PASSWD=`openssl rand -base64 32 | head -c 16`
+echo "API credentials are ${API_USER} - ${API_PASSWD}"
+
+/bin/node /var/ossec/api/configuration/auth/htpasswd -c /var/ossec/api/configuration/auth/user -b ${API_USER} ${API_PASSWD}
+
 cd /var/ossec
 for ossecdir in "${DATA_DIRS[@]}"; do
   mv ${ossecdir} ${ossecdir}-template


### PR DESCRIPTION
I think hardcoded credentials are bad, especially if users don't think about it and expose this docker container outside.

I added a small fix to auto generate the password. Username is hardcoded (well, at least it's not easily guessable!)