### PR TITLE
Improved Kibana Image to include all Dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,6 @@ services:
       - elasticsearch:elasticsearch
       - wazuh
     entrypoint: /wait-for-it.sh elasticsearch
-#    environment:
-#      - "WAZUH_KIBANA_PLUGIN_URL=http://your.repo/wazuhapp-3.1.0-6.1.2.zip"
   nginx:
     image: wazuh/wazuh-nginx
     hostname: nginx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,8 +78,6 @@ services:
       - wazuh
     entrypoint: /wait-for-it.sh elasticsearch
 #    environment:
-#      - http_proxy=yourproxy
-#      - https_proxy=yourproxy
 #      - "WAZUH_KIBANA_PLUGIN_URL=http://your.repo/wazuhapp-3.1.0-6.1.2.zip"
   nginx:
     image: wazuh/wazuh-nginx

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -6,4 +6,16 @@ COPY ./config/kibana.yml /usr/share/kibana/config/kibana.yml
 
 COPY config/wait-for-it.sh /wait-for-it.sh
 
+ADD https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.2.zip /tmp
+
+ADD https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/kibana/config
+
+ADD https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-monitoring.json /usr/share/kibana/config
+
+ADD https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/alert_sample.json /usr/share/kibana/config
+
+RUN /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-3.1.0_6.1.2.zip
+
+RUN rm -rf /tmp/*
+
 RUN chmod 755 /wait-for-it.sh

--- a/kibana/config/wait-for-it.sh
+++ b/kibana/config/wait-for-it.sh
@@ -5,7 +5,6 @@ set -e
 host="$1"
 shift
 cmd="kibana"
-WAZUH_KIBANA_PLUGIN_URL=${WAZUH_KIBANA_PLUGIN_URL:-https://packages.wazuh.com/wazuhapp/wazuhapp-3.1.0_6.1.2.zip}
 
 until curl -XGET $host:9200; do
   >&2 echo "Elastic is unavailable - sleeping"
@@ -16,26 +15,18 @@ done
 
 sleep 5
 #Insert default templates
-curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://elasticsearch:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
+cat /usr/share/kibana/config/wazuh-elastic6-template-alerts.json | curl -XPUT 'http://elasticsearch:9200/_template/wazuh' -H 'Content-Type: application/json' -d @-
 
 sleep 5
 #Insert default templates
-curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/wazuh-elastic6-template-monitoring.json | curl -XPUT 'http://elasticsearch:9200/_template/wazuh-agent' -H 'Content-Type: application/json' -d @-
+cat /usr/share/kibana/config/wazuh-elastic6-template-monitoring.json | curl -XPUT 'http://elasticsearch:9200/_template/wazuh-agent' -H 'Content-Type: application/json' -d @-
 
 #Insert sample alert:
 sleep 5
-curl https://raw.githubusercontent.com/wazuh/wazuh/3.1/extensions/elasticsearch/alert_sample.json | curl -XPUT "http://elasticsearch:9200/wazuh-alerts-3.x-"`date +%Y.%m.%d`"/wazuh/sample" -H 'Content-Type: application/json' -d @-
+cat /usr/share/kibana/config/alert_sample.json | curl -XPUT "http://elasticsearch:9200/wazuh-alerts-3.x-"`date +%Y.%m.%d`"/wazuh/sample" -H 'Content-Type: application/json' -d @-
 
-if /usr/share/kibana/bin/kibana-plugin list | grep wazuh; then
-  echo "Wazuh APP already installed"
-else
-  /usr/share/kibana/bin/kibana-plugin install ${WAZUH_KIBANA_PLUGIN_URL}
-fi
-
-sleep 30
-
+sleep 5
 echo "Setting API credentials into Wazuh APP"
-
 CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET http://$host:9200/.wazuh/wazuh-configuration/1513629884013)
 if [ "x$CONFIG_CODE" = "x404" ]; then
   curl -s -XPOST http://$host:9200/.wazuh/wazuh-configuration/1513629884013 -H 'Content-Type: application/json' -d'


### PR DESCRIPTION
The Kibana image does now include all dependencies and has the plugin build in. 
So there is no need for the Kibana container to access the internet or install the plugin on start as it is all included. 

So there was also no need anymore for the http_proxy env variable in docker-compose.yml and the other env variables also. 

This works flawless behind a corp proxy but pls test this for your deployment first.
! This needs the dockerhub kibana image to get updated !

This Fixes #34 