### PR TITLE
Add a mount point for custom Wazuh configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In addition, a docker-compose file is provided to launch the containers mentione
 
 ## Current release
 
-Containers are currently tested on Wazuh version 3.1.0 and Elastic Stack version 6.1.0. We will do our best to keep this repository updated to latest versions of both Wazuh and Elastic Stack.
+Containers are currently tested on Wazuh version 3.2.0 and Elastic Stack version 6.2.1. We will do our best to keep this repository updated to latest versions of both Wazuh and Elastic Stack.
 
 ## Installation notes
 
@@ -26,6 +26,33 @@ To run all docker instances you can just run ``docker-compose up``, from the dir
 * It is recommended to set Docker host preferences to give at least 4GB memory per container (this doesn't necessarily mean they all will use it, but Elasticsearch requires them to work properly).
 
 Once installed you can browse through the interface at: http://127.0.0.1:5601
+
+## Mount custom Wazuh configuration files
+
+To mount custom Wazuh configuration files in the Wazuh manager container, mount them in the `/wazuh-config-mount` folder. For example, to mount a custom `ossec.conf` file, mount it in `/wazuh-config-mount/etc/ossec.conf` and the [run.sh](wazuh/config/run.sh) script will copy the file at the right place on boot while respecting the destination file permissions.
+
+Here is an example of a `/wazuh-config-mount` folder used to mount some common custom configuration files:
+```
+root@wazuh-manager:/# tree /wazuh-config-mount/
+/wazuh-config-mount/
+└── etc
+    ├── ossec.conf
+    ├── rules
+    │   └── local_rules.xml
+    └── shared
+        └── default
+            └── agent.conf
+
+4 directories, 3 files
+```
+
+In that case, you will see this in the Wazuh manager logs on boot:
+```
+Identified Wazuh configuration files to mount...
+'/wazuh-config-mount/etc/ossec.conf' -> '/var/ossec/data/etc/ossec.conf'
+'/wazuh-config-mount/etc/rules/local_rules.xml' -> '/var/ossec/data/etc/rules/local_rules.xml'
+'/wazuh-config-mount/etc/shared/default/agent.conf' -> '/var/ossec/data/etc/shared/default/agent.conf'
+```
 
 ## More documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
 #      - my-path:/var/ossec/data:Z
 #      - my-path:/etc/postfix:Z
 #      - my-path:/etc/filebeat
+#      - my-custom-config-path/ossec.conf:/wazuh-config-mount/etc/ossec.conf
     depends_on:
       - elasticsearch
   logstash:


### PR DESCRIPTION
Having a way to mount custom configuration files in the Wazuh manager container will be really useful!

Why do we need a mount point for those files?
* I first tried to mount the `ossec.conf` file at the `/var/ossec/etc/ossec.conf` path, but on the first boot of the container, the [`if [ ! -e "${DATA_PATH}/${ossecdir}" ]`](https://github.com/wazuh/wazuh-docker/blob/master/wazuh/config/run.sh#L38) condition becomes false for the `etc` folder and the initial Wazuh setup in the container fails (the `etc` folder contains only the `ossec.conf` file and some SSL keys).
* Then, I tried to mount the `ossec.conf` file at the `/var/ossec/etc-template/ossec.conf` path, it worked on the initial install, but since I use a persistent storage for the `/var/ossec/data` folder (an AWS EBS drive mounted in my container), when I try to update the configuration and try to reboot my container to mount the new configuration file, the  [`if [ ! -e "${DATA_PATH}/${ossecdir}" ]`](https://github.com/wazuh/wazuh-docker/blob/master/wazuh/config/run.sh#L38) condition is false for the `etc` folder, so my new file in `etc-template` doesn't get copied in `etc`.

So finally, by creating a mount point for configuration files, mounting the files works with a newly created Wazuh container or with an existing one that is rebooting.

I already tested these changes by overriding the `run.sh` file in my container, it works :)

Changes:
\+ Add a mount point for custom Wazuh configuration files

\+ Add documentation for that mount point

\! Fix the currently supported Wazuh and Elasticsearch versions in the README

\! Fix the ossec_shutdown function in the `wazuh/config/run.sh` file (/var/ossec/data/bin is not valid)