### PR TITLE
Allow custom scripts or commands before service start

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ Identified Wazuh configuration files to mount...
 '/wazuh-config-mount/etc/shared/default/agent.conf' -> '/var/ossec/data/etc/shared/default/agent.conf'
 ```
 
+## Custom commands/scripts
+
+To execute commands in the Wazuh manager container after configuration is placed but _before_ the
+Wazuh API and manager are started, pass the commands as the docker commands/arguments:
+
+```sh
+docker run -it --rm wazuh/wazuh:latest "echo 'hello world'" "uname -m" "ls /var/ossec"
+```
+
+A more real-world example:
+
+```sh
+docker run -it --rm wazuh/wazuh:latest "/var/ossec/bin/ossec-control enable debug"
+```
+
 ## More documentation
 
 * [Wazuh full documentation](http://documentation.wazuh.com)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
 #      - my-path:/etc/postfix:Z
 #      - my-path:/etc/filebeat
 #      - my-custom-config-path/ossec.conf:/wazuh-config-mount/etc/ossec.conf
+#   command: ["echo 'hello world'"]
     depends_on:
       - logstash
   logstash:

--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -125,7 +125,5 @@ do
   echo "Executing command \`${CUSTOM_COMMAND}\`"
   exec_cmd_stdout "${CUSTOM_COMMAND}"
 done
-  exec_cmd_stdout "${CUSTOM_COMMAND}"
-done
 
 /sbin/my_init 

--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -113,4 +113,16 @@ trap "ossec_shutdown; exit" SIGINT SIGTERM
 
 chmod -R g+rw ${DATA_PATH}
 
+##############################################################################
+# Interpret any passed arguments (via docker command to this entrypoint) as
+# paths or commands, and execute them.
+#
+# This can be useful for actions that need to be run before the services are
+# started, such as "/var/ossec/bin/ossec-control enable agentless".
+##############################################################################
+for CUSTOM_COMMAND in "$@"
+do
+  exec_cmd_stdout "${CUSTOM_COMMAND}"
+done
+
 /sbin/my_init 

--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -122,6 +122,9 @@ chmod -R g+rw ${DATA_PATH}
 ##############################################################################
 for CUSTOM_COMMAND in "$@"
 do
+  echo "Executing command \`${CUSTOM_COMMAND}\`"
+  exec_cmd_stdout "${CUSTOM_COMMAND}"
+done
   exec_cmd_stdout "${CUSTOM_COMMAND}"
 done
 


### PR DESCRIPTION
Addresses #57

This method is arguably only slightly less hacky than the two workarounds I added in #57, but it's a sounder strategy for automated installation than either of them.
