### PR TITLE
Set ossec user's home path

### DIFF
--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -15,7 +15,7 @@ RUN curl --silent --location https://deb.nodesource.com/setup_8.x | bash -
 
 # Creating ossec user as uid:gid 1000:1000
 RUN groupadd -g 1000 ossec
-RUN useradd -u 1000 -g 1000 ossec
+RUN useradd -u 1000 -g 1000 -d /var/ossec ossec
 
 # Configure postfix
 RUN echo "postfix postfix/mailname string wazuh-manager" | debconf-set-selections


### PR DESCRIPTION
ossec expected its user's home directory to be `/var/ossec`. (ossec's old docs (mentioned this in passing)[https://www.ossec.net/docs/manual/agent/agentless-monitoring.html], but I haven't found it anywhere in wazuh's docs yet).

`wazuh/wazuh` doesn't specify a home directory at all for the ossec user, meaning that it defaults to `/home/ossec`, which doesn't exist. This means that the `ssh-keygen` command in the agentless [How It Works](https://documentation.wazuh.com/current/user-manual/capabilities/agentless-monitoring/how-it-works.html) section can't be followed. I've made it so `/var/ossec` is the home directory.