### PR TITLE
Updating entrypoing.sh so upgrading is posible

### DIFF
--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -53,6 +53,14 @@ for ossecdir in "${DATA_DIRS[@]}"; do
   fi
 done
 
+
+if [  -e ${WAZUH_INSTALL_PATH}/etc-template  ]
+then
+    cp -p /var/ossec/etc-template/internal_options.conf /var/ossec/etc/internal_options.conf
+fi
+rm /var/ossec/queue/db/.template.db
+
+
 touch ${DATA_PATH}/process_list
 chgrp ossec ${DATA_PATH}/process_list
 chmod g+rw ${DATA_PATH}/process_list


### PR DESCRIPTION
It fixes  #76. The correct internal_options is copied over the outdated. It also removes /var/ossec/queue/db/.template.db so upgrade is posible.