### PR TITLE
entrypoint.sh updated so docker upgrade is posible

### DIFF
--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -53,6 +53,12 @@ for ossecdir in "${DATA_DIRS[@]}"; do
   fi
 done
 
+if [  -e ${WAZUH_INSTALL_PATH}/etc-template  ]
+then
+    cp -p /var/ossec/etc-template/internal_options.conf /var/ossec/etc/internal_options.conf
+fi
+rm /var/ossec/queue/db/.template.db
+
 touch ${DATA_PATH}/process_list
 chgrp ossec ${DATA_PATH}/process_list
 chmod g+rw ${DATA_PATH}/process_list


### PR DESCRIPTION
It fixes #76. When using external volumes in docker the outdated internal_options.conf is kept. Because of this and overwrite of the internal_options.conf file with the one of the new version is needed. Also /var/ossec/queue/db/.template.db needs to be deleted in case a change in the database schema.  
To correct this issues a fix is includead in entrypoint.sh. This fix overwrites the  the outdated internal_options.conf with the one of the new version and also deletes  /var/ossec/queue/db/.template.db so when the manager starts the dabase could be regenerated with the new schema.