### PR TITLE
Add env credentials for nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -13,4 +13,7 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 VOLUME ["/etc/nginx/conf.d"]
 
+ENV NGINX_NAME="foo" \
+    NGINX_PWD="bar"
+
 ENTRYPOINT /entrypoint.sh

--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 # Configuring default credentiales.
 if [ ! -f /etc/nginx/conf.d/kibana.htpasswd ]; then
   echo "Setting Nginx credentials"
-  echo bar|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd foo >/dev/null
+ echo $NGINX_PWD|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd $NGINX_NAME >/dev/null
 else
   echo "Kibana credentials already configured"
 fi

--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -15,7 +15,7 @@ fi
 # Configuring default credentiales.
 if [ ! -f /etc/nginx/conf.d/kibana.htpasswd ]; then
   echo "Setting Nginx credentials"
- echo $NGINX_PWD|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd $NGINX_NAME >/dev/null
+  echo $NGINX_PWD|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd $NGINX_NAME >/dev/null
 else
   echo "Kibana credentials already configured"
 fi


### PR DESCRIPTION
Hello team,

To better manage Nginx credentials at Docker and Kubernetes, we have added the necessary environment variables. 

Regards,

Alfonso Ruiz-Bravo 