### PR TITLE
Upgrade version 3.8.0_6.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## Wazuh Docker v3.8.0_6.5.4
 
+### Changed
+
+- Upgrade version 3.8.0_6.5.4 ([#97](https://github.com/wazuh/wazuh-docker/pull/97))
+
 ## Wazuh Docker v3.7.2_6.5.4
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ In addition, a docker-compose file is provided to launch the containers mentione
 * [Wazuh documentation for Docker](https://documentation.wazuh.com/current/docker/index.html)
 * [Docker hub](https://hub.docker.com/u/wazuh)
 
-## Current release
-
-Containers are currently tested on Wazuh version 3.8.0 and Elastic Stack version 6.5.4. We will do our best to keep this repository updated to latest versions of both Wazuh and Elastic Stack.
-
 ## Directory structure
 
 	wazuh-docker

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In addition, a docker-compose file is provided to launch the containers mentione
 
 ## Current release
 
-Containers are currently tested on Wazuh version 3.7.2 and Elastic Stack version 6.5.4. We will do our best to keep this repository updated to latest versions of both Wazuh and Elastic Stack.
+Containers are currently tested on Wazuh version 3.8.0 and Elastic Stack version 6.5.4. We will do our best to keep this repository updated to latest versions of both Wazuh and Elastic Stack.
 
 ## Directory structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   wazuh:
-    image: wazuh/wazuh:3.7.2_6.5.4
+    image: wazuh/wazuh:3.8.0_6.5.4
     hostname: wazuh-manager
     restart: always
     ports:
@@ -23,7 +23,7 @@ services:
     depends_on:
       - logstash
   logstash:
-    image: wazuh/wazuh-logstash:3.7.2_6.5.4
+    image: wazuh/wazuh-logstash:3.8.0_6.5.4
     hostname: logstash
     restart: always
 #    volumes:
@@ -61,7 +61,7 @@ services:
     networks:
         - docker_elk
   kibana:
-    image: wazuh/wazuh-kibana:3.7.2_6.5.4
+    image: wazuh/wazuh-kibana:3.8.0_6.5.4
     hostname: kibana
     restart: always
 #    ports:
@@ -76,7 +76,7 @@ services:
       - elasticsearch:elasticsearch
       - wazuh:wazuh
   nginx:
-    image: wazuh/wazuh-nginx:3.7.2_6.5.4
+    image: wazuh/wazuh-nginx:3.8.0_6.5.4
     hostname: nginx
     restart: always
     environment:

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,11 +1,11 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
 FROM docker.elastic.co/kibana/kibana:6.5.4
-ARG WAZUH_APP_VERSION=3.7.2_6.5.4
+ARG WAZUH_APP_VERSION=3.8.0_6.5.4
 USER root
 
 ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
 
-ADD https://raw.githubusercontent.com/wazuh/wazuh/3.7/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/kibana/config
+ADD https://raw.githubusercontent.com/wazuh/wazuh/3.8/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/kibana/config
 
 RUN NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip &&\
     chown -R kibana:kibana /usr/share/kibana &&\

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
 FROM phusion/baseimage:latest
 ARG FILEBEAT_VERSION=6.5.4
-ARG WAZUH_VERSION=3.7.2-1
+ARG WAZUH_VERSION=3.8.0-1
 
 # Updating image
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"

--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -107,9 +107,6 @@ else
   print "No Wazuh configuration files to mount..."
 fi
 
-# Enabling ossec-authd.
-exec_cmd "/var/ossec/bin/ossec-control enable auth"
-
 function ossec_shutdown(){
   ${WAZUH_INSTALL_PATH}/bin/ossec-control stop;
 }


### PR DESCRIPTION
Hello team,

This PR updates the Wazuh version to 3.8.0 as requested in issue #96.

The only notable change is the removal of the command that enables **authd**, because it no longer exists. 

Best regards,

Alfonso Ruiz-Bravo 