### PR TITLE
Remove cluster.py work around

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Upgrade version 3.8.0_6.5.4 ([#97](https://github.com/wazuh/wazuh-docker/pull/97))
+- Upgrade version 3.8.0_6.5.4. ([#97](https://github.com/wazuh/wazuh-docker/pull/97))
+
+### Removed
+
+- Remove cluster.py work around. ([#99](https://github.com/wazuh/wazuh-docker/pull/99))
 
 ## Wazuh Docker v3.7.2_6.5.4
 

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -76,8 +76,5 @@ RUN mkdir /etc/service/filebeat
 COPY config/filebeat.runit.service /etc/service/filebeat/run
 RUN chmod +x /etc/service/filebeat/run
 
-# Temporary fix for Wazuh cluster master node in Kubernetes
-RUN sed -i '87d;88d' /var/ossec/framework/wazuh/cluster/cluster.py
-
 # Run all services
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hello team,

The workaround did in Wazuh Dockerfile:

https://github.com/wazuh/wazuh-docker/blob/master/wazuh/Dockerfile#L81

It's no longer necessary. In version 3.8.0 those lines no longer exist due PR [#2227](https://github.com/wazuh/wazuh/pull/2227)

The issue #83 is solved.

Best regards,

Alfonso Ruiz-Bravo