### PR TITLE
Add Wazuh-Elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 
 services:
   wazuh:
-    image: wazuh/wazuh:3.8.1_6.5.4
+    image: wazuh/wazuh:3.8.2_6.5.4
     hostname: wazuh-manager
     restart: always
     ports:
@@ -23,7 +23,7 @@ services:
     depends_on:
       - logstash
   logstash:
-    image: wazuh/wazuh-logstash:3.8.1_6.5.4
+    image: wazuh/wazuh-logstash:3.8.2_6.5.4
     hostname: logstash
     restart: always
 #    volumes:
@@ -39,7 +39,7 @@ services:
     environment:
       - LS_HEAP_SIZE=2048m
   elasticsearch:
-    image: wazuh/wazuh-elasticsearch:3.8.1_6.5.4
+    image: wazuh/wazuh-elasticsearch:3.8.2_6.5.4
     hostname: elasticsearch
     restart: always
     ports:
@@ -61,7 +61,7 @@ services:
     networks:
         - docker_elk
   kibana:
-    image: wazuh/wazuh-kibana:3.8.1_6.5.4
+    image: wazuh/wazuh-kibana:3.8.2_6.5.4
     hostname: kibana
     restart: always
 #    ports:
@@ -76,7 +76,7 @@ services:
       - elasticsearch:elasticsearch
       - wazuh:wazuh
   nginx:
-    image: wazuh/wazuh-nginx:3.8.1_6.5.4
+    image: wazuh/wazuh-nginx:3.8.2_6.5.4
     hostname: nginx
     restart: always
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     environment:
       - LS_HEAP_SIZE=2048m
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+    image: wazuh/wazuh-elasticsearch:3.8.1_6.5.4
     hostname: elasticsearch
     restart: always
     ports:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,7 +1,5 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.4
-ENV ES_TMPDIR "/tmp"
-ENV ES_VERSION 6.5.4
 
 ENV ALERTS_SHARDS="1" \
     ALERTS_REPLICAS="0"
@@ -9,7 +7,9 @@ ENV ALERTS_SHARDS="1" \
 ENV API_USER="foo" \
     API_PASS="bar"
 
-ADD https://raw.githubusercontent.com/wazuh/wazuh/3.8/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/elasticsearch/config
+ENV TEMPLATE_VERSION=v3.8.2
+
+ADD https://raw.githubusercontent.com/wazuh/wazuh/$TEMPLATE_VERSION/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/elasticsearch/config
 
 COPY config/entrypoint.sh /entrypoint.sh
 
@@ -19,4 +19,5 @@ COPY --chown=elasticsearch:elasticsearch ./config/load_settings.sh ./
 
 RUN chmod +x ./load_settings.sh
 
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["elasticsearch"]

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,0 +1,19 @@
+# Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.5.4
+ENV ES_TMPDIR "/tmp"
+ENV ES_VERSION 6.5.4
+
+ENV ALERTS_SHARDS="1" \
+    ALERTS_REPLICAS="0"
+
+ADD https://raw.githubusercontent.com/wazuh/wazuh/3.8/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/elasticsearch/config
+
+COPY config/entrypoint.sh /entrypoint.sh
+
+RUN chmod 755 /entrypoint.sh
+
+COPY --chown=elasticsearch:elasticsearch ./config/load_settings.sh ./
+
+RUN chmod +x ./load_settings.sh
+
+ENTRYPOINT /entrypoint.sh

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -6,6 +6,9 @@ ENV ES_VERSION 6.5.4
 ENV ALERTS_SHARDS="1" \
     ALERTS_REPLICAS="0"
 
+ENV API_USER="foo" \
+    API_PASS="YmFy"
+
 ADD https://raw.githubusercontent.com/wazuh/wazuh/3.8/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/elasticsearch/config
 
 COPY config/entrypoint.sh /entrypoint.sh

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -7,7 +7,7 @@ ENV ALERTS_SHARDS="1" \
     ALERTS_REPLICAS="0"
 
 ENV API_USER="foo" \
-    API_PASS="YmFy"
+    API_PASS="bar"
 
 ADD https://raw.githubusercontent.com/wazuh/wazuh/3.8/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/elasticsearch/config
 

--- a/elasticsearch/config/entrypoint.sh
+++ b/elasticsearch/config/entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	set -- su-exec eulasticsearch "$@"
 	ES_JAVA_OPTS="-Des.network.host=$NETWORK_HOST -Des.logger.level=$LOG_LEVEL -Xms$HEAP_SIZE -Xmx$HEAP_SIZE"  $@ &
 else
-	$r@ &
+	$@ &
 fi
 
 ./load_settings.sh &

--- a/elasticsearch/config/entrypoint.sh
+++ b/elasticsearch/config/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -m
+
+# Add elasticsearch as command if needed
+if [ "${1:0:1}" = '-' ]; then
+	set -- elasticsearch "$@"
+fi
+
+if [ "$NODE_NAME" = "" ]; then
+	export NODE_NAME=$HOSTNAME
+fi
+
+if [ "x${ELASTICSEARCH_URL}" = "x" ]; then
+  el_url="https://elasticsearch:9200"
+else
+  el_url="${ELASTICSEARCH_URL}"
+fi
+
+# Run as user "elasticsearch" if the command is "elasticsearch"
+if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
+	set -- su-exec eulasticsearch "$@"
+	ES_JAVA_OPTS="-Des.network.host=$NETWORK_HOST -Des.logger.level=$LOG_LEVEL -Xms$HEAP_SIZE -Xmx$HEAP_SIZE"  $@ &
+else
+	$r@ &
+fi
+
+./load_settings.sh &
+
+su -c "elasticsearch " elasticsearch

--- a/elasticsearch/config/entrypoint.sh
+++ b/elasticsearch/config/entrypoint.sh
@@ -25,4 +25,4 @@ run_as_other_user_if_needed() {
 
 # Execute elasticsearch
 
-run_as_other_user_if_needed /usr/share/elasticsearch/bin/elasticsearch "${es_opts[@]}"
+run_as_other_user_if_needed /usr/share/elasticsearch/bin/elasticsearch 

--- a/elasticsearch/config/entrypoint.sh
+++ b/elasticsearch/config/entrypoint.sh
@@ -20,9 +20,9 @@ fi
 # Run as user "elasticsearch" if the command is "elasticsearch"
 if [ "$1" = 'elasticsearch' -a "$(id -u)" = '0' ]; then
 	set -- su-exec eulasticsearch "$@"
-	ES_JAVA_OPTS="-Des.network.host=$NETWORK_HOST -Des.logger.level=$LOG_LEVEL -Xms$HEAP_SIZE -Xmx$HEAP_SIZE"  $@ &
+	ES_JAVA_OPTS="-Des.network.host=$NETWORK_HOST -Des.logger.level=$LOG_LEVEL -Xms$HEAP_SIZE -Xmx$HEAP_SIZE"  "$@" &
 else
-	$@ &
+	"$@" &
 fi
 
 ./load_settings.sh &

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -23,13 +23,15 @@ sed -i 's|    "index.refresh_interval": "5s"|    "index.refresh_interval": "5s",
 cat /usr/share/elasticsearch/config/wazuh-elastic6-template-alerts.json | curl -XPUT "$el_url/_template/wazuh" -H 'Content-Type: application/json' -d @-
 sleep 5
 
+API_PASSWORD=`echo -n $API_PASS | base64`
+
 echo "Setting API credentials into Wazuh APP"
 CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/wazuh-configuration/1513629884013)
 if [ "x$CONFIG_CODE" = "x404" ]; then
   curl -s -XPOST $el_url/.wazuh/wazuh-configuration/1513629884013 -H 'Content-Type: application/json' -d'
   {
     "api_user": "'"$API_USER"'",
-    "api_password": "'"$API_PASS"'",
+    "api_password": "'"$API_PASSWORD"'",
     "url": "https://wazuh",
     "api_port": "55000",
     "insecure": "true",

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -28,8 +28,8 @@ CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/wazuh-
 if [ "x$CONFIG_CODE" = "x404" ]; then
   curl -s -XPOST $el_url/.wazuh/wazuh-configuration/1513629884013 -H 'Content-Type: application/json' -d'
   {
-    "api_user": "foo",
-    "api_password": "YmFy",
+    "api_user": "'"$API_USER"'",
+    "api_password": "'"$API_PASS"'",
     "url": "https://wazuh",
     "api_port": "55000",
     "insecure": "true",

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
+
+set -e
+
+if [ "x${ELASTICSEARCH_URL}" = "x" ]; then
+  el_url="http://elasticsearch:9200"
+else
+  el_url="${ELASTICSEARCH_URL}"
+fi
+
+until curl -XGET $el_url; do
+  >&2 echo "Elastic is unavailable - sleeping"
+  sleep 5
+done
+
+>&2 echo "Elastic is up - executing command"
+
+#Insert default templates
+
+sed -i 's|    "index.refresh_interval": "5s"|    "index.refresh_interval": "5s",    "number_of_shards" :   '"${ALERTS_SHARDS}"',    "number_of_replicas" : '"${ALERTS_REPLICAS}"'|' /usr/share/elasticsearch/config/wazuh-elastic6-template-alerts.json
+
+cat /usr/share/elasticsearch/config/wazuh-elastic6-template-alerts.json | curl -XPUT "$el_url/_template/wazuh" -H 'Content-Type: application/json' -d @-
+sleep 5
+
+echo "Setting API credentials into Wazuh APP"
+CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/wazuh-configuration/1513629884013)
+if [ "x$CONFIG_CODE" = "x404" ]; then
+  curl -s -XPOST $el_url/.wazuh/wazuh-configuration/1513629884013 -H 'Content-Type: application/json' -d'
+  {
+    "api_user": "foo",
+    "api_password": "YmFy",
+    "url": "https://wazuh",
+    "api_port": "55000",
+    "insecure": "true",
+    "component": "API",
+    "cluster_info": {
+      "manager": "wazuh-manager",
+      "cluster": "Disabled",
+      "status": "disabled"
+    },
+    "extensions": {
+      "oscap": true,
+      "audit": true,
+      "pci": true,
+      "aws": true,
+      "virustotal": true,
+      "gdpr": true,
+      "ciscat": true
+    }
+  }
+  ' > /dev/null
+else
+  echo "Wazuh APP already configured"
+fi
+sleep 5
+
+curl -XPUT "$el_url/_cluster/settings" -H 'Content-Type: application/json' -d'
+{
+  "persistent": {
+    "xpack.monitoring.collection.enabled": true
+  }
+}
+'
+
+echo "Elasticsearch is ready."

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -23,14 +23,17 @@ sed -i 's|    "index.refresh_interval": "5s"|    "index.refresh_interval": "5s",
 cat /usr/share/elasticsearch/config/wazuh-elastic6-template-alerts.json | curl -XPUT "$el_url/_template/wazuh" -H 'Content-Type: application/json' -d @-
 sleep 5
 
-API_PASSWORD=`echo -n $API_PASS | base64`
+
+API_PASS_Q=`echo "$API_PASS" | tr -d '"'`
+API_USER_Q=`echo "$API_USER" | tr -d '"'`
+API_PASSWORD=`echo -n $API_PASS_Q | base64`
 
 echo "Setting API credentials into Wazuh APP"
 CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/wazuh-configuration/1513629884013)
 if [ "x$CONFIG_CODE" = "x404" ]; then
   curl -s -XPOST $el_url/.wazuh/wazuh-configuration/1513629884013 -H 'Content-Type: application/json' -d'
   {
-    "api_user": "'"$API_USER"'",
+    "api_user": "'"$API_USER_Q"'",
     "api_password": "'"$API_PASSWORD"'",
     "url": "https://wazuh",
     "api_port": "55000",

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,6 +1,6 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
 FROM docker.elastic.co/kibana/kibana:6.5.4
-ARG WAZUH_APP_VERSION=3.8.1_6.5.4
+ARG WAZUH_APP_VERSION=3.8.2_6.5.4
 USER root
 
 ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -5,8 +5,6 @@ USER root
 
 ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
 
-ADD https://raw.githubusercontent.com/wazuh/wazuh/3.8/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/kibana/config
-
 RUN NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip &&\
     chown -R kibana:kibana /usr/share/kibana &&\
     rm -rf /tmp/*

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -16,41 +16,6 @@ done
 
 >&2 echo "Elastic is up - executing command"
 
-#Insert default templates
-cat /usr/share/kibana/config/wazuh-elastic6-template-alerts.json | curl -XPUT "$el_url/_template/wazuh" -H 'Content-Type: application/json' -d @-
-sleep 5
-
-echo "Setting API credentials into Wazuh APP"
-CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/wazuh-configuration/1513629884013)
-if [ "x$CONFIG_CODE" = "x404" ]; then
-  curl -s -XPOST $el_url/.wazuh/wazuh-configuration/1513629884013 -H 'Content-Type: application/json' -d'
-  {
-    "api_user": "foo",
-    "api_password": "YmFy",
-    "url": "https://wazuh",
-    "api_port": "55000",
-    "insecure": "true",
-    "component": "API",
-    "cluster_info": {
-      "manager": "wazuh-manager",
-      "cluster": "Disabled",
-      "status": "disabled"
-    },
-    "extensions": {
-      "oscap": true,
-      "audit": true,
-      "pci": true,
-      "aws": true,
-      "virustotal": true,
-      "gdpr": true,
-      "ciscat": true
-    }
-  }
-  ' > /dev/null
-else
-  echo "Wazuh APP already configured"
-fi
-sleep 5
 
 ./wazuh_app_config.sh
 

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -3,6 +3,8 @@ FROM phusion/baseimage:latest
 ARG FILEBEAT_VERSION=6.5.4
 ARG WAZUH_VERSION=3.8.1-1
 
+ENV API_USER="foo" \
+    API_PASS="bar"
 
 # Updating image
 RUN apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold"

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
 FROM phusion/baseimage:latest
 ARG FILEBEAT_VERSION=6.5.4
-ARG WAZUH_VERSION=3.8.1-1
+ARG WAZUH_VERSION=3.8.2-1
 
 ENV API_USER="foo" \
     API_PASS="bar"

--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -129,4 +129,19 @@ do
   exec_cmd_stdout "${CUSTOM_COMMAND}"
 done
 
+
+##############################################################################
+# Change Wazuh API user credentials.
+##############################################################################
+
+
+pushd /var/ossec/api/configuration/auth/
+
+echo "Change Wazuh API user credentials"
+change_user="node htpasswd -b -c user $API_USER $API_PASS"
+eval $change_user
+
+popd
+
+
 /sbin/my_init 


### PR DESCRIPTION
Hello team,

This PR solves #108 and creates the Wazuh-Elasticsearch module. This is done to properly separate the tasks concerning each container. The configurations of each container only depend on itself and not on another container. 

To this end, we have transferred the modifications made to the Elasticsearch container from the Kibana container.

 We have also added the option of configuring API credentials using environment variables so that they are not embedded in the code. 


We have performed tests of various types:

- Clean deployment.
- Deployment with new API credentials.
- Deployment enabling volumes for Elasticsearch and Wazuh.
- Registration of agents. 
- Verification of the persistence of agent registration, configuration changes and alerts through the use of volumes.
- Verification of the functioning of the environment after removing the Elasticsearch container and creating it again. 

All tests have been successful. 


Best regards,

Alfonso Ruiz-Bravo
