### PR TITLE
Filebeat registry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
 #      - my-path:/var/ossec/data:Z
 #      - my-path:/etc/postfix:Z
 #      - my-path:/etc/filebeat
-#      - my_path:/var/lib/filebeat/registry
+#      - my_path:/var/lib/filebeat
 #      - my-custom-config-path/ossec.conf:/wazuh-config-mount/etc/ossec.conf
 #   command: ["echo 'hello world'"]
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 #      - my-path:/var/ossec/data:Z
 #      - my-path:/etc/postfix:Z
 #      - my-path:/etc/filebeat
+#      - my_path:/var/lib/filebeat/registry
 #      - my-custom-config-path/ossec.conf:/wazuh-config-mount/etc/ossec.conf
 #   command: ["echo 'hello world'"]
     depends_on:

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -53,6 +53,7 @@ RUN chmod 755 /entrypoint.sh
 VOLUME ["/var/ossec/data"]
 VOLUME ["/etc/filebeat"]
 VOLUME ["/etc/postfix"]
+VOLUME ["/var/lib/filebeat/registry"]
 
 # Services ports
 EXPOSE 55000/tcp 1514/udp 1515/tcp 514/udp 1516/tcp

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -53,7 +53,7 @@ RUN chmod 755 /entrypoint.sh
 VOLUME ["/var/ossec/data"]
 VOLUME ["/etc/filebeat"]
 VOLUME ["/etc/postfix"]
-VOLUME ["/var/lib/filebeat/registry"]
+VOLUME ["/var/lib/filebeat"]
 
 # Services ports
 EXPOSE 55000/tcp 1514/udp 1515/tcp 514/udp 1516/tcp


### PR DESCRIPTION
Hello team, 

This PR solves issue #107.

We have performed tests, enabling volumes for **Elasticsearch**, **Wazuh** and **/var/lib/filebeat**. We have subsequently inserted alerts on several occasions, destroying and recreating the containers. 

The result is that the alerts are not duplicated.

Kind regards,

Alfonso Ruiz-Bravo