### PR TITLE
Adding the option to disable some xpack features

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -7,6 +7,8 @@ ENV ALERTS_SHARDS="1" \
 ENV API_USER="foo" \
     API_PASS="bar"
 
+ENV XPACK_ML="false" 
+
 ENV TEMPLATE_VERSION=v3.8.2
 
 ADD https://raw.githubusercontent.com/wazuh/wazuh/$TEMPLATE_VERSION/extensions/elasticsearch/wazuh-elastic6-template-alerts.json /usr/share/elasticsearch/config

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -7,7 +7,7 @@ ENV ALERTS_SHARDS="1" \
 ENV API_USER="foo" \
     API_PASS="bar"
 
-ENV XPACK_ML="false" 
+ENV XPACK_ML="true" 
 
 ENV TEMPLATE_VERSION=v3.8.2
 

--- a/elasticsearch/config/entrypoint.sh
+++ b/elasticsearch/config/entrypoint.sh
@@ -19,6 +19,28 @@ run_as_other_user_if_needed() {
   fi
 }
 
+
+#Disabling xpack features
+
+elasticsearch_config_file="/usr/share/elasticsearch/config/elasticsearch.yml"
+if grep -Fq  "#xpack features" "$elasticsearch_config_file";
+then 
+  declare -A CONFIG_MAP=(
+  [xpack.ml.enabled]=$XPACK_ML
+  )
+  for i in "${!CONFIG_MAP[@]}"
+  do
+    if [ "${CONFIG_MAP[$i]}" != "" ]; then
+      sed -i 's/.'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $elasticsearch_config_file
+    fi
+  done
+else
+  echo "
+#xpack features
+xpack.ml.enabled: $XPACK_ML
+ " >> $elasticsearch_config_file
+fi
+
 # Run load settings script.
 
 ./load_settings.sh &

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -84,9 +84,9 @@ then
   done
 else
   echo "
-  #xpack features
-  xpack.ml.enabled: $XPACK_ML
-  " >> $elasticsearch_config_file
+#xpack features
+xpack.ml.enabled: $XPACK_ML
+ " >> $elasticsearch_config_file
 fi
 
 echo "Elasticsearch is ready."

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -68,25 +68,5 @@ curl -XPUT "$el_url/_cluster/settings" -H 'Content-Type: application/json' -d'
 }
 '
 
-#Disabling xpack features
-
-elasticsearch_config_file="/usr/share/elasticsearch/config/elasticsearch.yml"
-if grep -Fq  "#xpack features" "$elasticsearch_config_file";
-then 
-  declare -A CONFIG_MAP=(
-  [xpack.ml.enabled]=$XPACK_ML
-  )
-  for i in "${!CONFIG_MAP[@]}"
-  do
-    if [ "${CONFIG_MAP[$i]}" != "" ]; then
-      sed -i 's/.'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $elasticsearch_config_file
-    fi
-  done
-else
-  echo "
-#xpack features
-xpack.ml.enabled: $XPACK_ML
- " >> $elasticsearch_config_file
-fi
 
 echo "Elasticsearch is ready."

--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -68,4 +68,25 @@ curl -XPUT "$el_url/_cluster/settings" -H 'Content-Type: application/json' -d'
 }
 '
 
+#Disabling xpack features
+
+elasticsearch_config_file="/usr/share/elasticsearch/config/elasticsearch.yml"
+if grep -Fq  "#xpack features" "$elasticsearch_config_file";
+then 
+  declare -A CONFIG_MAP=(
+  [xpack.ml.enabled]=$XPACK_ML
+  )
+  for i in "${!CONFIG_MAP[@]}"
+  do
+    if [ "${CONFIG_MAP[$i]}" != "" ]; then
+      sed -i 's/.'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $elasticsearch_config_file
+    fi
+  done
+else
+  echo "
+  #xpack features
+  xpack.ml.enabled: $XPACK_ML
+  " >> $elasticsearch_config_file
+fi
+
 echo "Elasticsearch is ready."

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -39,7 +39,13 @@ ENV PATTERN="" \
     WAZUH_MONITORING_FREQUENCY="" \
     WAZUH_MONITORING_SHARDS="" \
     WAZUH_MONITORING_REPLICAS="" \
-    ADMIN_PRIVILEGES=""
+    ADMIN_PRIVILEGES=""\
+    XPACK_CANVAS="false"\
+    XPACK_LOGS="false"\
+    XPACK_INFRA="false"\
+    XPACK_ML="false"\
+    XPACK_DEVTOOLS="false"\
+    XPACK_APM="false"
 
 
 COPY --chown=kibana:kibana ./config/wazuh_app_config.sh ./
@@ -49,6 +55,10 @@ RUN chmod +x ./wazuh_app_config.sh
 COPY --chown=kibana:kibana ./config/kibana_settings.sh ./
 
 RUN chmod +x ./kibana_settings.sh
+
+COPY --chown=kibana:kibana ./config/xpack_config.sh ./
+
+RUN chmod +x ./xpack_config.sh
 
 ENTRYPOINT /entrypoint.sh
 

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -40,13 +40,13 @@ ENV PATTERN="" \
     WAZUH_MONITORING_SHARDS="" \
     WAZUH_MONITORING_REPLICAS="" \
     ADMIN_PRIVILEGES=""\
-    XPACK_CANVAS="false"\
-    XPACK_LOGS="false"\
-    XPACK_INFRA="false"\
-    XPACK_ML="false"\
-    XPACK_DEVTOOLS="false"\
-    XPACK_MONITORING="false"\
-    XPACK_APM="false"
+    XPACK_CANVAS="true"\
+    XPACK_LOGS="true"\
+    XPACK_INFRA="true"\
+    XPACK_ML="true"\
+    XPACK_DEVTOOLS="true"\
+    XPACK_MONITORING="true"\
+    XPACK_APM="true"
 
 
 COPY --chown=kibana:kibana ./config/wazuh_app_config.sh ./

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -45,6 +45,7 @@ ENV PATTERN="" \
     XPACK_INFRA="false"\
     XPACK_ML="false"\
     XPACK_DEVTOOLS="false"\
+    XPACK_MONITORING="false"\
     XPACK_APM="false"
 
 

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -23,4 +23,7 @@ sleep 5
 
 ./kibana_settings.sh &
 
+
+./xpack_config.sh &
+
 /usr/local/bin/kibana-docker

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -21,9 +21,10 @@ done
 
 sleep 5
 
+./xpack_config.sh 
+
 ./kibana_settings.sh &
 
 
-./xpack_config.sh &
 
 /usr/local/bin/kibana-docker

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -47,48 +47,4 @@ sleep 5
 # Do not ask user to help providing usage statistics to Elastic
 curl -POST "http://kibana:5601/api/telemetry/v1/optIn" -H "Content-Type: application/json" -H "kbn-xsrf: true" -d '{"enabled":false}'
 
-
-kibana_config_file="/usr/share/kibana/plugins/wazuh/config.yml"
-if grep -vq  "#xpack features" "$kibana_config_file";
-then 
-
-echo "
-#xpack features
-xpack.apm.ui.enabled: false
-xpack.grokdebugger.enabled: false
-xpack.searchprofiler.enabled: false
-xpack.security.enabled: false
-xpack.graph.enabled: false
-xpack.ml.enabled: false
-xpack.monitoring.enabled: false
-xpack.reporting.enabled: false
-xpack.watcher.enabled: false
-" >> /usr/share/kibana/config/kibana.yml
-
-else
-
-
-declare -A CONFIG_MAP=(
-
-[xpack.apm.ui.enabled]= $XPACK_APM
-[xpack.grokdebugger.enabled]= $XPACK_DEVTOOLS
-[xpack.searchprofiler.enabled]= $XPACK_DEVTOOLS
-[xpack.security.enable]= $XPACK_SECURITY
-[xpack.graph.enabled]= $XPACK_GRAPHS
-[xpack.ml.enabled]=$XPACK_MACHINELEARNING
-[xpack.monitoring.enabled]= $XPACK_MONITORING
-[xpack.reporting.enable]= $XPACK_REPORTING
-[xpack.watcher.enabled]= $XPACK_WATCHER
-)
-
-for i in "${!CONFIG_MAP[@]}"
-do
-    if [ "${CONFIG_MAP[$i]}" != "" ]; then
-        sed -i 's/.*'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $kibana_config_file
-    fi
-done
-
-fi
-
-
 echo "End settings"

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -47,4 +47,48 @@ sleep 5
 # Do not ask user to help providing usage statistics to Elastic
 curl -POST "http://kibana:5601/api/telemetry/v1/optIn" -H "Content-Type: application/json" -H "kbn-xsrf: true" -d '{"enabled":false}'
 
+
+kibana_config_file="/usr/share/kibana/plugins/wazuh/config.yml"
+if grep -vq  "#xpack features" "$kibana_config_file";
+then 
+
+echo "
+#xpack features
+xpack.apm.ui.enabled: false
+xpack.grokdebugger.enabled: false
+xpack.searchprofiler.enabled: false
+xpack.security.enabled: false
+xpack.graph.enabled: false
+xpack.ml.enabled: false
+xpack.monitoring.enabled: false
+xpack.reporting.enabled: false
+xpack.watcher.enabled: false
+" >> /usr/share/kibana/config/kibana.yml
+
+else
+
+
+declare -A CONFIG_MAP=(
+
+[xpack.apm.ui.enabled]= $XPACK_APM
+[xpack.grokdebugger.enabled]= $XPACK_DEVTOOLS
+[xpack.searchprofiler.enabled]= $XPACK_DEVTOOLS
+[xpack.security.enable]= $XPACK_SECURITY
+[xpack.graph.enabled]= $XPACK_GRAPHS
+[xpack.ml.enabled]=$XPACK_MACHINELEARNING
+[xpack.monitoring.enabled]= $XPACK_MONITORING
+[xpack.reporting.enable]= $XPACK_REPORTING
+[xpack.watcher.enabled]= $XPACK_WATCHER
+)
+
+for i in "${!CONFIG_MAP[@]}"
+do
+    if [ "${CONFIG_MAP[$i]}" != "" ]; then
+        sed -i 's/.*'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $kibana_config_file
+    fi
+done
+
+fi
+
+
 echo "End settings"

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -20,14 +20,14 @@ then
   done
 else
   echo "
-  #xpack features
-  xpack.apm.ui.enabled: $XPACK_APM 
-  xpack.grokdebugger.enabled: $XPACK_DEVTOOLS
-  xpack.searchprofiler.enabled: $XPACK_DEVTOOLS
-  xpack.ml.enabled: $XPACK_ML
-  xpack.canvas.enabled: $XPACK_CANVAS
-  xpack.logstash.enabled: $XPACK_LOGS
-  xpack.infra.enabled: $XPACK_INFRA
-  console.enabled: $XPACK_INFRA
-  " >> $kibana_config_file
+#xpack features
+xpack.apm.ui.enabled: $XPACK_APM 
+xpack.grokdebugger.enabled: $XPACK_DEVTOOLS
+xpack.searchprofiler.enabled: $XPACK_DEVTOOLS
+xpack.ml.enabled: $XPACK_ML
+xpack.canvas.enabled: $XPACK_CANVAS
+xpack.logstash.enabled: $XPACK_LOGS
+xpack.infra.enabled: $XPACK_INFRA
+console.enabled: $XPACK_INFRA
+" >> $kibana_config_file
 fi

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -11,6 +11,7 @@ then
     [xpack.canvas.enabled]=$XPACK_CANVAS
     [xpack.logstash.enabled]=$XPACK_LOGS
     [xpack.infra.enabled]=$XPACK_INFRA
+    [console.enabled]=$XPACK_DEVTOOLS
   )
   for i in "${!CONFIG_MAP[@]}"
   do
@@ -28,6 +29,6 @@ xpack.ml.enabled: $XPACK_ML
 xpack.canvas.enabled: $XPACK_CANVAS
 xpack.logstash.enabled: $XPACK_LOGS
 xpack.infra.enabled: $XPACK_INFRA
-console.enabled: $XPACK_INFRA
+console.enabled: $XPACK_DEVTOOLS
 " >> $kibana_config_file
 fi

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -11,6 +11,7 @@ then
     [xpack.canvas.enabled]=$XPACK_CANVAS
     [xpack.logstash.enabled]=$XPACK_LOGS
     [xpack.infra.enabled]=$XPACK_INFRA
+    [xpack.monitoring.enabled]=$XPACK_MONITORING
     [console.enabled]=$XPACK_DEVTOOLS
   )
   for i in "${!CONFIG_MAP[@]}"
@@ -29,6 +30,7 @@ xpack.ml.enabled: $XPACK_ML
 xpack.canvas.enabled: $XPACK_CANVAS
 xpack.logstash.enabled: $XPACK_LOGS
 xpack.infra.enabled: $XPACK_INFRA
+xpack.monitoring.enabled: $XPACK_MONITORING
 console.enabled: $XPACK_DEVTOOLS
 " >> $kibana_config_file
 fi

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+kibana_config_file="/usr/share/kibana/config/kibana.yml"
+if grep -Fq  "#xpack features" "$kibana_config_file";
+then 
+  declare -A CONFIG_MAP=(
+    [xpack.apm.ui.enabled]=$XPACK_APM
+    [xpack.grokdebugger.enabled]=$XPACK_DEVTOOLS
+    [xpack.searchprofiler.enabled]=$XPACK_DEVTOOLS
+    [xpack.ml.enabled]=$XPACK_ML
+    [xpack.canvas.enabled]=$XPACK_CANVAS
+    [xpack.logstash.enabled]=$XPACK_LOGS
+    [xpack.infra.enabled]=$XPACK_INFRA
+  )
+  for i in "${!CONFIG_MAP[@]}"
+  do
+    if [ "${CONFIG_MAP[$i]}" != "" ]; then
+      sed -i 's/.'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $kibana_config_file
+    fi
+  done
+else
+  echo "
+  #xpack features
+  xpack.apm.ui.enabled: $XPACK_APM 
+  xpack.grokdebugger.enabled: $XPACK_DEVTOOLS
+  xpack.searchprofiler.enabled: $XPACK_DEVTOOLS
+  xpack.ml.enabled: $XPACK_ML
+  xpack.canvas.enabled: $XPACK_CANVAS
+  xpack.logstash.enabled: $XPACK_LOGS
+  xpack.infra.enabled: $XPACK_INFRA
+  console.enabled: $XPACK_INFRA
+  " >> $kibana_config_file
+fi


### PR DESCRIPTION
Hi team,
this PR solves - https://github.com/wazuh/wazuh-saas/issues/41. It adds the capacity of enabling and disabling xpack features mainly at Kibana but also disable by default xpack machinelearning from the elasticsearch image. All these changes happen when the container is created and it is possible to enable and disable xpacks features using environment variables. For example:
```yml
  kibana:
    build: ./kibana
    hostname: kibana
    restart: always
#    ports:
#      - "5601:5601"
    environment:
      - ELASTICSEARCH_URL=http://elasticsearch:9200
      - XPACK_DEVTOOLS=true
      - XPACK_CANVAS=false
      - XPACK_LOGS=true
```
The docker-compose that can be seen above enables the devtools and logs plugin  at Kibana and disables the canvas plugin. Right now by default devtools, canvas, infraestructure, machinelearning, logs and apm are disabled by defautl. When a wazuh-kibana  container is created it will have the following appearance:

![image](https://user-images.githubusercontent.com/17405573/52278648-cf666a80-2957-11e9-8a84-c334d918f96a.png)

A battery of tests were done:
- All the docker images were deleted, then all the images were built and containers were created with  the default settings.  The following was checked:
  - no errors were found in the logs.
  -  was able to access the Wazuh app at Kibana. 
  - was checked that some alerts were received from the manager. 
  - also was checked that the kibana.yml and the elasticserach.yml had the correct values. 
- The containers were launched again with the same settings. No duplicates values were found at kibana.yml and the elasticserach.yml.  They had the same values.

- The values of the  environment variables were inverted. The containers were created again  and the correct values were found at the .yml configuration files. Then the containers were stopped and started again. No duplicate values, no bad indentations and again the correct values were found at the .yml files.

- Also an hybrid test was done with some variables set to true and other to false and checked that the corresponding values were set at the .yml files.

The following environment variables were added at Kibana:
- XPACK_DEVTOOLS: enables/disables the devtools plugin.
- XPACK_CANVAS= enables/disables the canvas plugin.
 - XPACK_LOGS= enables/disables the logs plugins.
 - XPACK_INFRA= enables/disables the infraestructure plugins.
 - XPACK_ML= enables/disables the Machine Learning plugin.
 - XPACK_APM= enables/disables the devtools plugins.
They need to have the values true for enabling a feature and false to disable it.