### PR TITLE
Wazuh-Kibana customizable at plugin level

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,13 +1,13 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
-FROM wazuh/wazuh-kibana:3.8.2_6.5.4
-#ARG WAZUH_APP_VERSION=3.8.2_6.5.4
+FROM docker.elastic.co/kibana/kibana:6.5.4
+ARG WAZUH_APP_VERSION=3.8.2_6.5.4
 USER root
 
-#ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
+ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
 
-#RUN NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip &&\
-#    chown -R kibana:kibana /usr/share/kibana &&\
-#    rm -rf /tmp/*
+RUN NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip &&\
+    chown -R kibana:kibana /usr/share/kibana &&\
+    rm -rf /tmp/*
 
 COPY config/entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
@@ -39,14 +39,15 @@ ENV PATTERN="" \
     WAZUH_MONITORING_FREQUENCY="" \
     WAZUH_MONITORING_SHARDS="" \
     WAZUH_MONITORING_REPLICAS="" \
-    ADMIN_PRIVILEGES=""\
-    XPACK_CANVAS="false"\
-    XPACK_LOGS="false"\
-    XPACK_INFRA="false"\
-    XPACK_ML="false"\
-    XPACK_DEVTOOLS="false"\
-    XPACK_MONITORING="false"\
-    XPACK_APM="false"
+    ADMIN_PRIVILEGES=""
+
+ARG XPACK_CANVAS="true"
+ARG XPACK_LOGS="true"
+ARG XPACK_INFRA="true"
+ARG XPACK_ML="true"
+ARG XPACK_DEVTOOLS="true"
+ARG XPACK_MONITORING="true"
+ARG XPACK_APM="true"
 
 
 COPY --chown=kibana:kibana ./config/wazuh_app_config.sh ./
@@ -66,4 +67,3 @@ RUN ./xpack_config.sh
 RUN /usr/local/bin/kibana-docker --optimize
 
 ENTRYPOINT /entrypoint.sh
-

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,13 +1,13 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
-FROM docker.elastic.co/kibana/kibana:6.5.4
-ARG WAZUH_APP_VERSION=3.8.2_6.5.4
+FROM wazuh/wazuh-kibana:3.8.2_6.5.4
+#ARG WAZUH_APP_VERSION=3.8.2_6.5.4
 USER root
 
-ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
+#ADD https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
 
-RUN NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip &&\
-    chown -R kibana:kibana /usr/share/kibana &&\
-    rm -rf /tmp/*
+#RUN NODE_OPTIONS="--max-old-space-size=3072" /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip &&\
+#    chown -R kibana:kibana /usr/share/kibana &&\
+#    rm -rf /tmp/*
 
 COPY config/entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh
@@ -40,13 +40,13 @@ ENV PATTERN="" \
     WAZUH_MONITORING_SHARDS="" \
     WAZUH_MONITORING_REPLICAS="" \
     ADMIN_PRIVILEGES=""\
-    XPACK_CANVAS="true"\
-    XPACK_LOGS="true"\
-    XPACK_INFRA="true"\
-    XPACK_ML="true"\
-    XPACK_DEVTOOLS="true"\
-    XPACK_MONITORING="true"\
-    XPACK_APM="true"
+    XPACK_CANVAS="false"\
+    XPACK_LOGS="false"\
+    XPACK_INFRA="false"\
+    XPACK_ML="false"\
+    XPACK_DEVTOOLS="false"\
+    XPACK_MONITORING="false"\
+    XPACK_APM="false"
 
 
 COPY --chown=kibana:kibana ./config/wazuh_app_config.sh ./
@@ -60,6 +60,10 @@ RUN chmod +x ./kibana_settings.sh
 COPY --chown=kibana:kibana ./config/xpack_config.sh ./
 
 RUN chmod +x ./xpack_config.sh
+
+RUN ./xpack_config.sh
+
+RUN /usr/local/bin/kibana-docker --optimize
 
 ENTRYPOINT /entrypoint.sh
 

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -21,7 +21,7 @@ done
 
 sleep 5
 
-./xpack_config.sh 
+#./xpack_config.sh 
 
 ./kibana_settings.sh &
 

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -21,10 +21,6 @@ done
 
 sleep 5
 
-#./xpack_config.sh 
-
 ./kibana_settings.sh &
-
-
 
 /usr/local/bin/kibana-docker


### PR DESCRIPTION
Hello team,

This PR solves issue #114.

The Wazuh-Kibana image can now be built using arguments to manage the plugins we want to have enabled.

```
ARG XPACK_CANVAS="true"
ARG XPACK_LOGS="true"
ARG XPACK_INFRA="true"
ARG XPACK_ML="true"
ARG XPACK_DEVTOOLS="true"
ARG XPACK_MONITORING="true"
ARG XPACK_APM="true"
```

By default, we will have all plugins enabled being the construction command the following:

`$ docker build kibana`

For each plugin we want to disable we'll have to add arguments to the command: 

`$ docker build kibana --build-arg  ARG_KEY_1=ARG_VALUE_1 . . . --build-arg  ARG_KEY_n=ARG_VALUE_n`

To disable all plugins the command would be serious:

`$ docker build kibana --build-arg XPACK_CANVAS="false" --build-arg  XPACK_LOGS="false" --build-arg XPACK_INFRA="false" --build-arg XPACK_ML="false" --build-arg XPACK_DEVTOOLS="false" --build-arg XPACK_MONITORING="false" --build-arg XPACK_APM="false"`

Finally we add to **Dockerfile** the Kibana command to optimize plugins in case we have enabled new plugins or disabled active plugins. 

`RUN /usr/local/bin/kibana-docker --optimize`

In this way we avoid that in the creation of the containers we have functions that delay the process as it happened with the optimization. 

Best regards,

Alfonso Ruiz-Bravo
