### PR TITLE
Fixing docker run loop at the elasticsearch container

### DIFF
--- a/elasticsearch/config/load_settings.sh
+++ b/elasticsearch/config/load_settings.sh
@@ -4,7 +4,7 @@
 set -e
 
 if [ "x${ELASTICSEARCH_URL}" = "x" ]; then
-  el_url="http://elasticsearch:9200"
+  el_url="http://localhost:9200"
 else
   el_url="${ELASTICSEARCH_URL}"
 fi


### PR DESCRIPTION
This PR fix - https://github.com/wazuh/wazuh-docker/issues/123. A change was made at the url where the elasticsearch configuration is set. Instead of "elasticsearch" that was set up by docker-compose "localhost| is used because when the container is run outside of docker-compose it will enter in a infinite loop because it cant resolve "elasticsearch".