### PR TITLE
New Logstash entrypoint added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Adding the option to disable some xpack features. ([#111](https://github.com/wazuh/wazuh-docker/pull/111))
 - Wazuh-Kibana customizable at plugin level. ([#117](https://github.com/wazuh/wazuh-docker/pull/117))
 - Adding env variables for alerts data flow. ([#118](https://github.com/wazuh/wazuh-docker/pull/118))
+- New Logstash entrypoint added. ([#135](https://github.com/wazuh/wazuh-docker/pull/135/files))
 
 ### Changed
 

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -31,7 +31,7 @@ strlen=0
 
 while [[ $strlen -eq 0 ]]
 do
-  template=$(curl $el_url:9200/_cat/templates/wazuh -s)
+  template=$(curl $el_url/_cat/templates/wazuh -s)
   strlen=${#template}
   >&2 echo "Wazuh alerts template not loaded - sleeping."
   sleep 2

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -33,11 +33,12 @@ while [[ $strlen -eq 0 ]]
 do
   template=$(curl $el_url:9200/_cat/templates/wazuh -s)
   strlen=${#template}
+  >&2 echo "Wazuh alerts template not loaded - sleeping."
 done
 
 sleep 10
 
->&2 echo "Wazuh alerts template is load."
+>&2 echo "Wazuh alerts template is loaded."
 
 
 ./wazuh_app_config.sh

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -18,7 +18,7 @@ until curl -XGET $el_url; do
   sleep 5
 done
 
-sleep 10
+sleep 2
 
 >&2 echo "Elasticsearch is up."
 
@@ -34,9 +34,10 @@ do
   template=$(curl $el_url:9200/_cat/templates/wazuh -s)
   strlen=${#template}
   >&2 echo "Wazuh alerts template not loaded - sleeping."
+  sleep 2
 done
 
-sleep 10
+sleep 2
 
 >&2 echo "Wazuh alerts template is loaded."
 

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -10,11 +10,13 @@ else
 fi
 
 until curl -XGET $el_url; do
-  >&2 echo "Elastic is unavailable - sleeping"
+  >&2 echo "Elastic is unavailable - sleeping."
   sleep 5
 done
 
->&2 echo "Elastic is up - executing command"
+sleep 10
+
+>&2 echo "Elasticsearch is up."
 
 
 ./wazuh_app_config.sh

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -3,6 +3,10 @@
 
 set -e
 
+##############################################################################
+# Waiting for elasticsearch
+##############################################################################
+
 if [ "x${ELASTICSEARCH_URL}" = "x" ]; then
   el_url="http://elasticsearch:9200"
 else
@@ -17,6 +21,23 @@ done
 sleep 10
 
 >&2 echo "Elasticsearch is up."
+
+
+##############################################################################
+# Waiting for wazuh alerts template
+##############################################################################
+
+strlen=0
+
+while [[ $strlen -eq 0 ]]
+do
+  template=$(curl $el_url:9200/_cat/templates/wazuh -s)
+  strlen=${#template}
+done
+
+sleep 10
+
+>&2 echo "Wazuh alerts template is load."
 
 
 ./wazuh_app_config.sh

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 FROM docker.elastic.co/logstash/logstash:6.5.4
 
-COPY config/entrypoint.sh /entrypoint.sh
+COPY --chown=logstash:logstash config/entrypoint.sh /entrypoint.sh
 
 RUN chmod 755 /entrypoint.sh
 

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -9,4 +9,4 @@ USER root
 COPY config/run.sh /run.sh
 RUN chmod +x /run.sh
 
-ENTRYPOINT ["/run.sh"]
+ENTRYPOINT /entrypoint.sh

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -1,6 +1,10 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 FROM docker.elastic.co/logstash/logstash:6.5.4
 
+COPY config/entrypoint.sh /entrypoint.sh
+
+RUN chmod 755 /entrypoint.sh
+
 RUN rm -f /usr/share/logstash/pipeline/logstash.conf
 
 COPY config/01-wazuh.conf /usr/share/logstash/pipeline/01-wazuh.conf

--- a/logstash/Dockerfile
+++ b/logstash/Dockerfile
@@ -9,8 +9,4 @@ RUN rm -f /usr/share/logstash/pipeline/logstash.conf
 
 COPY config/01-wazuh.conf /usr/share/logstash/pipeline/01-wazuh.conf
 
-USER root
-COPY config/run.sh /run.sh
-RUN chmod +x /run.sh
-
 ENTRYPOINT /entrypoint.sh

--- a/logstash/config/entrypoint.sh
+++ b/logstash/config/entrypoint.sh
@@ -1,24 +1,46 @@
-#!/bin/bash -e
+#!/bin/bash
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 #
 # OSSEC container bootstrap. See the README for information of the environment
 # variables expected by this script.
 #
 
+set -e
 
+##############################################################################
+# Waiting for elasticsearch
+##############################################################################
+
+if [ "x${ELASTICSEARCH_URL}" = "x" ]; then
+  el_url="http://elasticsearch:9200"
+else
+  el_url="${ELASTICSEARCH_URL}"
+fi
+
+until curl -XGET $el_url; do
+  >&2 echo "Elastic is unavailable - sleeping."
+  sleep 5
+done
+
+sleep 10
+
+>&2 echo "Elasticsearch is up."
 
 ##############################################################################
 # Customize logstash output ip
 ##############################################################################
 if [ "$LOGSTASH_OUTPUT" != "" ]; then
+  echo "Customize Logstash ouput ip."
   sed -i "s/elasticsearch:9200/$LOGSTASH_OUTPUT:9200/" /usr/share/logstash/pipeline/01-wazuh.conf
   sed -i "s/elasticsearch:9200/$LOGSTASH_OUTPUT:9200/" /usr/share/logstash/config/logstash.yml 
 fi
 
+##############################################################################
 # Map environment variables to entries in logstash.yml.
 # Note that this will mutate logstash.yml in place if any such settings are found.
 # This may be undesirable, especially if logstash.yml is bind-mounted from the
 # host system.
+##############################################################################
 
 env2yaml /usr/share/logstash/config/logstash.yml
 

--- a/logstash/config/entrypoint.sh
+++ b/logstash/config/entrypoint.sh
@@ -34,7 +34,7 @@ strlen=0
 
 while [[ $strlen -eq 0 ]]
 do
-  template=$(curl $el_url:9200/_cat/templates/wazuh -s)
+  template=$(curl $el_url/_cat/templates/wazuh -s)
   strlen=${#template}
   >&2 echo "Wazuh alerts template not loaded - sleeping."
   sleep 2

--- a/logstash/config/entrypoint.sh
+++ b/logstash/config/entrypoint.sh
@@ -22,7 +22,7 @@ until curl -XGET $el_url; do
   sleep 5
 done
 
-sleep 10
+sleep 2
 
 >&2 echo "Elasticsearch is up."
 
@@ -37,9 +37,10 @@ do
   template=$(curl $el_url:9200/_cat/templates/wazuh -s)
   strlen=${#template}
   >&2 echo "Wazuh alerts template not loaded - sleeping."
+  sleep 2
 done
 
-sleep 10
+sleep 2
 
 >&2 echo "Wazuh alerts template is loaded."
 

--- a/logstash/config/entrypoint.sh
+++ b/logstash/config/entrypoint.sh
@@ -27,10 +27,27 @@ sleep 10
 >&2 echo "Elasticsearch is up."
 
 ##############################################################################
+# Waiting for wazuh alerts template
+##############################################################################
+
+strlen=0
+
+while [[ $strlen -eq 0 ]]
+do
+  template=$(curl $el_url:9200/_cat/templates/wazuh -s)
+  strlen=${#template}
+done
+
+sleep 10
+
+>&2 echo "Wazuh alerts template is load."
+
+##############################################################################
 # Customize logstash output ip
 ##############################################################################
+
 if [ "$LOGSTASH_OUTPUT" != "" ]; then
-  echo "Customize Logstash ouput ip."
+  >&2 echo "Customize Logstash ouput ip."
   sed -i "s/elasticsearch:9200/$LOGSTASH_OUTPUT:9200/" /usr/share/logstash/pipeline/01-wazuh.conf
   sed -i "s/elasticsearch:9200/$LOGSTASH_OUTPUT:9200/" /usr/share/logstash/config/logstash.yml 
 fi

--- a/logstash/config/entrypoint.sh
+++ b/logstash/config/entrypoint.sh
@@ -36,11 +36,12 @@ while [[ $strlen -eq 0 ]]
 do
   template=$(curl $el_url:9200/_cat/templates/wazuh -s)
   strlen=${#template}
+  >&2 echo "Wazuh alerts template not loaded - sleeping."
 done
 
 sleep 10
 
->&2 echo "Wazuh alerts template is load."
+>&2 echo "Wazuh alerts template is loaded."
 
 ##############################################################################
 # Customize logstash output ip

--- a/logstash/config/entrypoint.sh
+++ b/logstash/config/entrypoint.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/bin/bash -e
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 #
 # OSSEC container bootstrap. See the README for information of the environment
 # variables expected by this script.
 #
+
+
 
 ##############################################################################
 # Customize logstash output ip
@@ -13,4 +15,17 @@ if [ "$LOGSTASH_OUTPUT" != "" ]; then
   sed -i "s/elasticsearch:9200/$LOGSTASH_OUTPUT:9200/" /usr/share/logstash/config/logstash.yml 
 fi
 
-/usr/local/bin/docker-entrypoint
+# Map environment variables to entries in logstash.yml.
+# Note that this will mutate logstash.yml in place if any such settings are found.
+# This may be undesirable, especially if logstash.yml is bind-mounted from the
+# host system.
+
+env2yaml /usr/share/logstash/config/logstash.yml
+
+export LS_JAVA_OPTS="-Dls.cgroup.cpuacct.path.override=/ -Dls.cgroup.cpu.path.override=/ $LS_JAVA_OPTS"
+
+if [[ -z $1 ]] || [[ ${1:0:1} == '-' ]] ; then
+  exec logstash "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Hello team,

This PR solves issue #132.

It was necessary to add certain race conditions for Logstash and Kibana. Both services will wait until the Wazuh alerts template is loaded.

Logstash lacked an entrypoint of its own and we created it, adding the run.sh lines that are no longer needed.

Best regards,

Alfonso Ruiz-Bravo 