### PR TITLE
Setting Nginx docker to support several user/passwords in Kibana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     restart: always
     environment:
       - NGINX_PORT=443
+      - NGINX_CREDENTIALS
     ports:
       - "80:80"
       - "443:443"

--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -13,6 +13,15 @@ else
 fi
 
 # Setting users credentials.
+# In order to set NGINX_CREDENTIALS, before "docker-compose up -d" run (a or b):
+#
+# a) export NGINX_CREDENTIALS="user1:pass1;user2:pass2;" or
+#    export NGINX_CREDENTIALS="user1:pass1;user2:pass2"
+#
+# b) Set NGINX_CREDENTIALS in docker-compose.yml:
+#    NGINX_CREDENTIALS=user1:pass1;user2:pass2; or
+#    NGINX_CREDENTIALS=user1:pass1;user2:pass2
+#
 if [ ! -f /etc/nginx/conf.d/kibana.htpasswd ]; then
   echo "Setting users credentials"
   if [ ! -z "$NGINX_CREDENTIALS" ]; then
@@ -27,6 +36,7 @@ if [ ! -f /etc/nginx/conf.d/kibana.htpasswd ]; then
       fi
     done
   else
+    # NGINX_PWD and NGINX_NAME are declared in nginx/Dockerfile 
     echo $NGINX_PWD|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd $NGINX_NAME >/dev/null
   fi
 else

--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
+# Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 
 set -e
 


### PR DESCRIPTION
Hi team,

In order to set users credentials, before " docker-compose up -d " run (a or b):
a) export NGINX_CREDENTIALS="user1:pass1;user2:pass2;"

b) Set NGINX_CREDENTIALS in docker-compose.yml:
   NGINX_CREDENTIALS=user1:pass1;user2:pass2;