### PR TITLE
Remove alerts created in build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ All notable changes to this project will be documented in this file.
 - Adding env variables for alerts data flow. ([#118](https://github.com/wazuh/wazuh-docker/pull/118))
 - New Logstash entrypoint added. ([#135](https://github.com/wazuh/wazuh-docker/pull/135/files))
 - Welcome screen management. ([#133](https://github.com/wazuh/wazuh-docker/pull/133))
-- Remove alerts created in build time. ([#137](https://github.com/wazuh/wazuh-docker/pull/137))
-
 
 ### Changed
 
 - Update to Wazuh version 3.8.2. ([#105](https://github.com/wazuh/wazuh-docker/pull/105))
+
+### Removed
+
+- Remove alerts created in build time. ([#137](https://github.com/wazuh/wazuh-docker/pull/137))
+
 
 ## Wazuh Docker v3.8.1_6.5.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Adding env variables for alerts data flow. ([#118](https://github.com/wazuh/wazuh-docker/pull/118))
 - New Logstash entrypoint added. ([#135](https://github.com/wazuh/wazuh-docker/pull/135/files))
 - Welcome screen management. ([#133](https://github.com/wazuh/wazuh-docker/pull/133))
+- Remove alerts created in build time. ([#137](https://github.com/wazuh/wazuh-docker/pull/137))
 
 
 ### Changed

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -17,7 +17,8 @@ RUN set -x && echo "deb https://packages.wazuh.com/3.x/apt/ stable main" | tee /
 RUN add-apt-repository universe && apt-get update && apt-get upgrade -y -o Dpkg::Options::="--force-confold" && \
    apt-get --no-install-recommends --no-install-suggests -y install openssl postfix bsd-mailx python-boto python-pip  \
    apt-transport-https vim expect nodejs python-cryptography mailutils libsasl2-modules wazuh-manager=${WAZUH_VERSION} \
-   wazuh-api=${WAZUH_VERSION} && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+   wazuh-api=${WAZUH_VERSION} && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -f \
+   /var/ossec/logs/alerts/*/*/*.log && rm -f /var/ossec/logs/alerts/*/*/*.json
 
 # Adding first run script and entrypoint
 COPY config/data_dirs.env /data_dirs.env
@@ -59,9 +60,6 @@ RUN chmod +x /etc/service/wazuh-api/run && \
     chmod +x /etc/service/wazuh/run && \
     chmod +x /etc/service/postfix/run && \
     chmod +x /etc/service/filebeat/run 
-
-RUN echo -n > /var/ossec/logs/alerts/alerts.json
-RUN echo -n > /var/ossec/logs/alerts/alerts.log
 
 # Run all services
 ENTRYPOINT ["/entrypoint.sh"]

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -60,6 +60,9 @@ RUN chmod +x /etc/service/wazuh-api/run && \
     chmod +x /etc/service/postfix/run && \
     chmod +x /etc/service/filebeat/run 
 
+RUN echo -n > /var/ossec/logs/alerts/alerts.json
+RUN echo -n > /var/ossec/logs/alerts/alerts.log
+
 # Run all services
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Hello team,

This PR is a workaround for issue #127. 

As long as the installation of the Wazuh manager involves a boot, we can only choose to remove the alerts that are created at that time. 

Best regards,

Alfonso Ruiz-Bravo