### PR TITLE
fix logstash heap size limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     depends_on:
       - elasticsearch
     environment:
-      - LS_HEAP_SIZE=2048m
+      - "LS_JAVA_OPTS=-Xmx2g"
   elasticsearch:
     image: wazuh/wazuh-elasticsearch:3.8.2_6.5.4
     hostname: elasticsearch


### PR DESCRIPTION
LS_HEAP_SIZE does not work for logstash versions >= 5.0.0 use LS_JAVA_OPTS instead