### PR TITLE
Fixing duplicate alerts with kubernetes

### DIFF
--- a/wazuh/config/filebeat.yml
+++ b/wazuh/config/filebeat.yml
@@ -8,6 +8,7 @@ filebeat:
     json.message_key: log
     json.keys_under_root: true
     json.overwrite_keys: true
+    tail_files: true
 
 output:
  logstash:


### PR DESCRIPTION
Hi team, 
this PR fixes https://github.com/wazuh/wazuh-kubernetes/issues/32. It adds the [tail_files](https://www.elastic.co/guide/en/beats/filebeat/1.2/configuration-filebeat-options.html#_tail_files) option to the Filebeat config file. Like it is said in the issue the main problem was that the device where the alerts.json was located changed between pods restarts so  filebeat though that it was a new file and starts reading it all over again. With this option the following is expected to happen:
- If the device doesn't change between restarts: the alerts.json file will be readed from the end the first time and the next reboots the  offset will be used to read the file. 
- If the device change: filebeat will  treat alerts.json as if it were new and will start reading  from the end each time. Then if the device dont change it will keep reading it as normally.
- If alerts.json was previously readed  without tails_file and the device has not changed it will be readed using the offset.

Some of the checks that I have done:
- Tried to find duplicates restarting containers at local and pods at our Kubernetes development environment. 
- Check that no alerts were lost when restarting the containers and the pods.
- Also checked that  no alerts were lost when the alerts.json rotates.
- Checked that no alerts were lost when a massive amount of alerts are generated.
