### PR TITLE
Removing files from Wazuh image

### DIFF
--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -18,7 +18,9 @@ RUN add-apt-repository universe && apt-get update && apt-get upgrade -y -o Dpkg:
    apt-get --no-install-recommends --no-install-suggests -y install openssl postfix bsd-mailx python-boto python-pip  \
    apt-transport-https vim expect nodejs python-cryptography mailutils libsasl2-modules wazuh-manager=${WAZUH_VERSION} \
    wazuh-api=${WAZUH_VERSION} && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && rm -f \
-   /var/ossec/logs/alerts/*/*/*.log && rm -f /var/ossec/logs/alerts/*/*/*.json
+   /var/ossec/logs/alerts/*/*/*.log && rm -f /var/ossec/logs/alerts/*/*/*.json && rm -f \
+   /var/ossec/logs/archives/*/*/*.log && rm -f /var/ossec/logs/archives/*/*/*.json && rm -f \
+   /var/ossec/logs/firewall/*/*/*.log && rm -f /var/ossec/logs/firewall/*/*/*.json
 
 # Adding first run script and entrypoint
 COPY config/data_dirs.env /data_dirs.env


### PR DESCRIPTION
Hi team!

This PR solves issue https://github.com/wazuh/wazuh-docker/issues/152 .

It removes `.log` and `.json` files from the following paths:
```
/var/ossec/logs/alerts/*/*/
/var/ossec/logs/archives/*/*/
/var/ossec/logs/firewall/*/*/
```

Best regards,
Mayte Ariza