### PR TITLE
Allow port change for elasticsearch url in kibana

### DIFF
--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -19,7 +19,7 @@ WAZUH_MAJOR=3
 # Customize elasticsearch ip
 ##############################################################################
 if [ "$ELASTICSEARCH_KIBANA_IP" != "" ]; then
-  sed -i "s/elasticsearch:9200/$ELASTICSEARCH_KIBANA_IP:9200/" /usr/share/kibana/config/kibana.yml
+  sed -i "s/elasticsearch:9200/$ELASTICSEARCH_KIBANA_IP/" /usr/share/kibana/config/kibana.yml
 fi
 
 if [ "$KIBANA_IP" != "" ]; then


### PR DESCRIPTION
Hello team,

this PR allows port customization for Kibana - Elasticsearch communication.
Useful when you are not using Elasticsearch default port.

Regards.