### PR TITLE
Changing Filebeat configuration if environment variable is set

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,20 +11,6 @@ services:
       - "1515:1515"
       - "514:514/udp"
       - "55000:55000"
-    depends_on:
-      - logstash
-  logstash:
-    image: wazuh/wazuh-logstash:3.9.2_7.1.1
-    hostname: logstash
-    restart: always
-    links:
-      - elasticsearch:elasticsearch
-    ports:
-      - "5000:5000"
-    depends_on:
-      - elasticsearch
-    environment:
-      - LS_HEAP_SIZE=2048m
   elasticsearch:
     image: wazuh/wazuh-elasticsearch:3.9.2_7.1.1
     hostname: elasticsearch

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -10,7 +10,6 @@ then
     [xpack.searchprofiler.enabled]=$XPACK_DEVTOOLS
     [xpack.ml.enabled]=$XPACK_ML
     [xpack.canvas.enabled]=$XPACK_CANVAS
-    [xpack.logstash.enabled]=$XPACK_LOGS
     [xpack.infra.enabled]=$XPACK_INFRA
     [xpack.monitoring.enabled]=$XPACK_MONITORING
     [console.enabled]=$XPACK_DEVTOOLS
@@ -29,7 +28,6 @@ xpack.grokdebugger.enabled: $XPACK_DEVTOOLS
 xpack.searchprofiler.enabled: $XPACK_DEVTOOLS
 xpack.ml.enabled: $XPACK_ML
 xpack.canvas.enabled: $XPACK_CANVAS
-xpack.logstash.enabled: $XPACK_LOGS
 xpack.infra.enabled: $XPACK_INFRA
 xpack.monitoring.enabled: $XPACK_MONITORING
 console.enabled: $XPACK_DEVTOOLS

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -32,6 +32,7 @@ COPY config/init.bash /init.bash
 RUN mkdir /entrypoint-scripts
 COPY config/entrypoint.sh /entrypoint.sh
 COPY config/00-wazuh.sh /entrypoint-scripts/00-wazuh.sh
+COPY config/01-config_filebeat.sh /entrypoint-scripts/01-config_filebeat.sh
 
 # Sync calls are due to https://github.com/docker/docker/issues/9547
 RUN chmod 755 /init.bash && \
@@ -40,10 +41,11 @@ RUN chmod 755 /init.bash && \
    curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-${FILEBEAT_VERSION}-amd64.deb &&\
    dpkg -i filebeat-${FILEBEAT_VERSION}-amd64.deb && rm -f filebeat-${FILEBEAT_VERSION}-amd64.deb && \
    chmod 755 /entrypoint.sh && \
-   chmod 755 /entrypoint-scripts/00-wazuh.sh 
+   chmod 755 /entrypoint-scripts/00-wazuh.sh && \
+   chmod 755 /entrypoint-scripts/01-config_filebeat.sh
 
 COPY config/filebeat.yml /etc/filebeat/
-RUN chmod go-w /etc/filebeat/filebeat.yml 
+RUN chmod go-w /etc/filebeat/filebeat.yml
 
 # Setting volumes
 VOLUME ["/var/ossec/data"]
@@ -76,4 +78,3 @@ RUN chmod go-w /etc/filebeat/wazuh-template.json
 
 # Run all services
 ENTRYPOINT ["/entrypoint.sh"]
-

--- a/wazuh/config/01-config_filebeat.sh
+++ b/wazuh/config/01-config_filebeat.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
+
+set -e
+
+# Modify the output to Elasticsearch if th ELASTICSEARCH_URL is set
+if [ "$ELASTICSEARCH_URL" != "" ]; then
+  >&2 echo "Customize Elasticsearch ouput IP."
+  sed -i 's|http://elasticsearch:9200|'$ELASTICSEARCH_URL'|g' /etc/filebeat/filebeat.yml
+fi


### PR DESCRIPTION
Hi folks,

This PR enables the ability to change the Elasticsearch output (`hosts`) if the `ELASTICSEARCH_URL` environment variable is set in the Wazuh container:

```
  wazuh:
    image: wazuh/wazuh:3.9.2_7.1.1
    hostname: wazuh-manager
    restart: always
    ports:
      - "1514:1514/udp"
      - "1515:1515"
      - "514:514/udp"
      - "55000:55000"
    environment:
      - ELASTICSEARCH_URL=https://customelk.com:9300
```

That configuration will change this option in the `filebeat.yml` configuration file:

```
output.elasticsearch:
  hosts: ['https://customelk.com:9300']
```

This PR also removes missing components of Logstash, related issue here: #191 

Cheers