### PR TITLE
Update to filebeat.yml for SRC and DST

### DIFF
--- a/wazuh/config/filebeat.yml
+++ b/wazuh/config/filebeat.yml
@@ -45,6 +45,34 @@ processors:
       when:
         regexp:
           data.win.eventdata.ipAddress: \b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b
+  - rename:
+      fields:
+        - from: "data.aws.srcaddr"
+          to: "@src_ip"
+      ignore_missing: true
+      fail_on_error: false
+      when:
+        regexp:
+          data.aws.srcaddr: \b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b
+  - rename:
+      fields:
+        - from: "data.win.eventdata.destinationIp"
+          to: "@dst_ip"
+      ignore_missing: true
+      fail_on_error: false
+      when:
+        regexp:
+          data.win.eventdata.destinationIp: \b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b
+  - rename:
+      fields:
+        - from: "data.aws.dstaddr"
+          to: "@dst_ip"
+      ignore_missing: true
+      fail_on_error: false
+      when:
+        regexp:
+          data.aws.dstaddr: \b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b
+
 
 output.elasticsearch:
   hosts: ['http://elasticsearch:9200']


### PR DESCRIPTION
Source
Add GeoIP support for VPC flow log events data.aws.srcaddr field. 
Add GeoIP support for Windows IIS 8 logs with x-forward-for field as httpRequest.clientIp for IIS servers behind AWS load balancer with x-forward-for configured in logs. 

Destination:
Add GeoIP support for data.win.eventdata.destinationIp
Add GeoIP support for data.aws.dstaddr