### PR TITLE
Grant read and write permissions for group 

### DIFF
--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -251,6 +251,11 @@ main() {
 
   # Delete temporary data folder
   rm -rf ${WAZUH_INSTALL_PATH}/data_tmp
+
+  # Grant proper permissions
+  # When modifiying some files using the Wazuh API (i.e. /var/ossec/etc/ossec.conf), group rw permissions are needed for changes to take place.  
+  # https://github.com/wazuh/wazuh/issues/3647
+  chmod -R g+rw ${WAZUH_INSTALL_PATH}
 }
 
 main


### PR DESCRIPTION
Hi team!!

This PR solves issue https://github.com/wazuh/wazuh-docker/issues/205. Read and write permissions are granted for `/var/ossec` path in order to modify files properly using the Wazuh API .

Best regards,
Mayte Ariza
