### PR TITLE
Check if file exists before removing it

### DIFF
--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -84,8 +84,9 @@ apply_exclusion_data() {
 
 remove_data_files() {
   for del_file in "${PERMANENT_DATA_DEL[@]}"; do
-    print "Removing ${del_file}"
-    exec_cmd "rm ${del_file}"
+    if [ -e ${del_file} ]
+      print "Removing ${del_file}"
+      exec_cmd "rm ${del_file}"
   done
 }
 


### PR DESCRIPTION
Hi team!!

This PR solves issue https://github.com/wazuh/wazuh-docker/issues/208. It is checked if every file contained in _PERMANENT_DATA_DEL_  exists before removing it to avoid exiting the script execution.

Best regards,
Mayte Ariza.
