### PR TITLE
Fixed duplicated cluster configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,22 +12,33 @@ services:
       - "514:514/udp"
       - "55000:55000"
   elasticsearch:
-    image: wazuh/wazuh-elasticsearch:3.9.2_7.1.1
+    build: elasticsearch
     hostname: elasticsearch
     restart: always
     ports:
       - "9200:9200"
     environment:
-      - node.name=node-1
-      - cluster.name=wazuh
-      - network.host=0.0.0.0
-      - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - ELASTIC_CLUSTER=true
+      - CLUSTER_NODE_MASTER=true
+      - CLUSTER_MASTER_NODE_NAME=es01
+
+  es02:
+    build: elasticsearch
+    hostname: es02
+    restart: always
+    environment:
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - ELASTIC_CLUSTER=true
+      - CLUSTER_MASTER_NODE_NAME=elasticsearch
+      - CLUSTER_NODE_NAME=es02
     ulimits:
       memlock:
         soft: -1
         hard: -1
     mem_limit: 2g
+
+
   kibana:
     image: wazuh/wazuh-kibana:3.9.2_7.1.1
     hostname: kibana

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -22,18 +22,17 @@ ARG TEMPLATE_VERSION=v3.9.2
 # CLUSTER_INITIAL_MASTER_NODES set to own node by default.
 ENV ELASTIC_CLUSTER="false" \
     CLUSTER_NAME="wazuh" \
-    CLUSTER_NODE_MASTER="true" \
+    CLUSTER_NODE_MASTER="false" \
     CLUSTER_NODE_DATA="true" \
     CLUSTER_NODE_INGEST="true" \
     CLUSTER_NODE_NAME="wazuh-elasticsearch" \
+    CLUSTER_MASTER_NODE_NAME="master-node" \
     CLUSTER_MEMORY_LOCK="true" \
     CLUSTER_DISCOVERY_SERVICE="wazuh-elasticsearch" \
     CLUSTER_NUMBER_OF_MASTERS="2" \
     CLUSTER_MAX_NODES="1" \
     CLUSTER_DELAYED_TIMEOUT="1m" \
     CLUSTER_INITIAL_MASTER_NODES="wazuh-elasticsearch"
-
-ADD https://raw.githubusercontent.com/wazuh/wazuh/$TEMPLATE_VERSION/extensions/elasticsearch/7.x/wazuh-template.json /usr/share/elasticsearch/config
 
 COPY config/entrypoint.sh /entrypoint.sh 
 


### PR DESCRIPTION
Hello team,

This PR fixes #195. The cluster configuration was reinserted to the `elasticsearch.yml` file when the containers were restarted. It's been solved by implementing the following logic:
- If the cluster isn't enabled using the `ELASTIC_CLUSTER` variable, then a single host configuration is set.
```
discovery.type: single-node
```
- If the cluster is enabled, then set a production configuration.

The reinserted data bug is fixed by deleting the previous configuration before inserting a new one:
```
sed -i '/# cluster node/,/# end cluster config/d' $elastic_config_file
remove_single_node_conf(){
  if grep -Fq "discovery.type" $1; then
    sed -i '/discovery.type\: /d' $1 
  fi
}
```

An example of a cluster configuration could be illustrated by the following `docker-compose.yml`:
```
  elasticsearch:
    build: elasticsearch
    hostname: elasticsearch
    restart: always
    ports:
      - "9200:9200"
    environment:
      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
      - ELASTIC_CLUSTER=true
      - CLUSTER_NODE_MASTER=true
      - CLUSTER_MASTER_NODE_NAME=es01

  es02:
    build: elasticsearch
    hostname: es02
    restart: always
    environment:
      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
      - ELASTIC_CLUSTER=true
      - CLUSTER_MASTER_NODE_NAME=elasticsearch
      - CLUSTER_NODE_NAME=es02
    ulimits:
      memlock:
        soft: -1
        hard: -1
    mem_limit: 2g
```
Regards