### PR TITLE
Adapt Kibana image to v7.2.0

### DIFF
--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -8,7 +8,7 @@ USER root
 
 ADD  https://packages.wazuh.com/wazuhapp/wazuhapp-${WAZUH_APP_VERSION}.zip /tmp
 
-RUN /usr/share/kibana/bin/kibana-plugin install file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip 
+RUN /usr/share/kibana/bin/kibana-plugin install --allow-root file:///tmp/wazuhapp-${WAZUH_APP_VERSION}.zip 
 RUN rm -rf /tmp/wazuhapp-${WAZUH_APP_VERSION}.zip
 
 COPY config/entrypoint.sh ./entrypoint.sh

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -74,6 +74,6 @@ curl -POST "http://$kibana_ip:5601/api/kibana/settings" -H "Content-Type: applic
 
 sleep 5
 # Do not ask user to help providing usage statistics to Elastic
-curl -POST "http://$kibana_ip:5601/api/telemetry/v1/optIn" -H "Content-Type: application/json" -H "kbn-xsrf: true" -d '{"enabled":false}'
+curl -POST "http://$kibana_ip:5601/api/telemetry/v2/optIn" -H "Content-Type: application/json" -H "kbn-xsrf: true" -d '{"enabled":false}'
 
 echo "End settings"


### PR DESCRIPTION
Hello team,

This PR mainly fixes #217 and also updates the RESTful API to the `v2` version. Since Elastic was updated, it was breaking our Docker Kibana build. Now the installation of the Wazuh plugin is done with the flag:
```
--allow-root
```

Cheers