### PR TITLE
Removed write permissions for group and other in Integrations folder

### DIFF
--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -259,6 +259,9 @@ main() {
   # When modifiying some files using the Wazuh API (i.e. /var/ossec/etc/ossec.conf), group rw permissions are needed for changes to take place.  
   # https://github.com/wazuh/wazuh/issues/3647
   chmod -R g+rw ${WAZUH_INSTALL_PATH}
+  
+  # Files inside /var/ossec/integrations should not have write permissions for group and other.
+  chmod -R go-w "/var/ossec/integrations/"
 }
 
 main

--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -261,7 +261,7 @@ main() {
   chmod -R g+rw ${WAZUH_INSTALL_PATH}
   
   # Files inside /var/ossec/integrations should not have write permissions for group and other.
-  chmod -R go-w "/var/ossec/integrations/"
+  chmod -R 750 "/var/ossec/integrations/"
 }
 
 main


### PR DESCRIPTION
Hi team!!

This PR solves issue https://github.com/wazuh/wazuh-docker/issues/225.  It **removes recursively write permissions** for _group and other_ in `/var/ossec/integrations` folder after granting read and write permissions recursively in `/var/ossec/` path.

Best regards,
Mayte Ariza