### PR TITLE
Added TLS version filter

### DIFF
--- a/kibana/config/20-entrypoint.sh
+++ b/kibana/config/20-entrypoint.sh
@@ -92,7 +92,7 @@ elasticsearch.ssl.certificateAuthorities: [\"/usr/share/kibana/config/$SECURITY_
 server.ssl.enabled: true
 server.ssl.certificate: $SECURITY_KIBANA_SSL_CERT_PATH/kibana-access.pem
 server.ssl.key: $SECURITY_KIBANA_SSL_KEY_PATH/kibana-access.key
-server.ssl.supportedProtocols: TLSv1.1, TLSv1.2
+server.ssl.supportedProtocols: [TLSv1.1, TLSv1.2]
 " >> /usr/share/kibana/config/kibana.yml
 
   echo "Create SSL directories."

--- a/kibana/config/20-entrypoint.sh
+++ b/kibana/config/20-entrypoint.sh
@@ -92,6 +92,7 @@ elasticsearch.ssl.certificateAuthorities: [\"/usr/share/kibana/config/$SECURITY_
 server.ssl.enabled: true
 server.ssl.certificate: $SECURITY_KIBANA_SSL_CERT_PATH/kibana-access.pem
 server.ssl.key: $SECURITY_KIBANA_SSL_KEY_PATH/kibana-access.key
+server.ssl.supportedProtocols: TLSv1.1, TLSv1.2
 " >> /usr/share/kibana/config/kibana.yml
 
   echo "Create SSL directories."

--- a/kibana/config/20-entrypoint.sh
+++ b/kibana/config/20-entrypoint.sh
@@ -92,7 +92,9 @@ elasticsearch.ssl.certificateAuthorities: [\"/usr/share/kibana/config/$SECURITY_
 server.ssl.enabled: true
 server.ssl.certificate: $SECURITY_KIBANA_SSL_CERT_PATH/kibana-access.pem
 server.ssl.key: $SECURITY_KIBANA_SSL_KEY_PATH/kibana-access.key
-server.ssl.supportedProtocols: [TLSv1.1, TLSv1.2]
+server.ssl.supportedProtocols: 
+  - TLSv1
+  - TLSv2
 " >> /usr/share/kibana/config/kibana.yml
 
   echo "Create SSL directories."

--- a/kibana/config/20-entrypoint.sh
+++ b/kibana/config/20-entrypoint.sh
@@ -93,8 +93,8 @@ server.ssl.enabled: true
 server.ssl.certificate: $SECURITY_KIBANA_SSL_CERT_PATH/kibana-access.pem
 server.ssl.key: $SECURITY_KIBANA_SSL_KEY_PATH/kibana-access.key
 server.ssl.supportedProtocols: 
-  - TLSv1
-  - TLSv2
+  - TLSv1.1
+  - TLSv1.2
 " >> /usr/share/kibana/config/kibana.yml
 
   echo "Create SSL directories."


### PR DESCRIPTION
Hi team, 

This PR adds `server.ssl.supportedProtocols` to Kibana in order to avoid TLSv1.

Best regards,
Josemi