### PR TITLE
Add wodles to permanent_data

### DIFF
--- a/wazuh/config/permanent_data.env
+++ b/wazuh/config/permanent_data.env
@@ -7,6 +7,7 @@ PERMANENT_DATA[((i++))]="/var/ossec/queue"
 PERMANENT_DATA[((i++))]="/var/ossec/var/multigroups"
 PERMANENT_DATA[((i++))]="/var/ossec/integrations"
 PERMANENT_DATA[((i++))]="/var/ossec/active-response/bin"
+PERMANENT_DATA[((i++))]="/var/ossec/wodles"
 PERMANENT_DATA[((i++))]="/etc/filebeat"
 PERMANENT_DATA[((i++))]="/etc/postfix"
 export PERMANENT_DATA


### PR DESCRIPTION
Hi team!!!

This PR adds `/var/ossec/wodles` path to PERMANENT_DATA variable in order to keep **permissions**, **ownership** and **files**.

Best regards,
Mayte Ariza