### PR TITLE
Fixed the option to change Filebeat output

### DIFF
--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -197,20 +197,6 @@ change_api_user_credentials() {
 }
 
 
-
-
-##############################################################################
-# Customize filebeat output ip
-##############################################################################
-
-
-custom_filebeat_output_ip() {
-  if [ "$FILEBEAT_OUTPUT" != "" ]; then
-    sed -i "s/logstash:5000/$FILEBEAT_OUTPUT:5000/" /etc/filebeat/filebeat.yml
-  fi
-}
-
-
 ##############################################################################
 # Main function
 ##############################################################################
@@ -254,9 +240,6 @@ main() {
 
   # Change API user credentials
   change_api_user_credentials
-
-  # Update filebeat configuration
-  custom_filebeat_output_ip
 
   # Delete temporary data folder
   rm -rf ${WAZUH_INSTALL_PATH}/data_tmp

--- a/wazuh/config/02-set_filebeat_destination.sh
+++ b/wazuh/config/02-set_filebeat_destination.sh
@@ -9,12 +9,17 @@ if [[ $FILEBEAT_DESTINATION == "elasticsearch" ]]; then
 
     echo "FILEBEAT - Set destination to Elasticsearch"
     cp filebeat_to_elasticsearch.yml /etc/filebeat/filebeat.yml
+    if [[ $FILEBEAT_OUTPUT != "" ]]; then
+        sed -i "s/elasticsearch:9200/$FILEBEAT_OUTPUT:9200/" /etc/filebeat/filebeat.yml
+    fi
 
 elif [[ $FILEBEAT_DESTINATION == "logstash" ]]; then
 
     echo "FILEBEAT - Set destination to Logstash"
     cp filebeat_to_logstash.yml /etc/filebeat/filebeat.yml
-    sed -i "s/logstash:5000/$FILEBEAT_OUTPUT:5000/" /etc/filebeat/filebeat.yml
+    if [[ $FILEBEAT_OUTPUT != "" ]]; then
+        sed -i "s/logstash:5000/$FILEBEAT_OUTPUT:5000/" /etc/filebeat/filebeat.yml
+    fi
 
 else
     echo "FILEBEAT - Error choosing destination. Set default filebeat.yml "

--- a/wazuh/config/02-set_filebeat_destination.sh
+++ b/wazuh/config/02-set_filebeat_destination.sh
@@ -14,6 +14,7 @@ elif [[ $FILEBEAT_DESTINATION == "logstash" ]]; then
 
     echo "FILEBEAT - Set destination to Logstash"
     cp filebeat_to_logstash.yml /etc/filebeat/filebeat.yml
+    sed -i "s/logstash:5000/$FILEBEAT_OUTPUT:5000/" /etc/filebeat/filebeat.yml
 
 else
     echo "FILEBEAT - Error choosing destination. Set default filebeat.yml "


### PR DESCRIPTION
Hello team,

Before the option to change the Filebeat output was done in a process prior to copying the configuration depending on the destination (Logstash or Elasticserach) therefore had no effect.

We have changed that code section so that it is done once the final configuration is established. 

Best regards,

Alfonso Ruiz-Bravo