### PR TITLE
Add workaround for vulnerability detector data published field

### DIFF
--- a/logstash/config/01-wazuh.conf
+++ b/logstash/config/01-wazuh.conf
@@ -40,6 +40,22 @@ filter {
         remove_field => [ "beat", "input_type", "tags", "count", "@version", "log", "offset", "type", "@src_ip", "host"]
     }
 }
+filter {
+    # Workarounds for vulnerability-detector
+    if "vulnerability-detector" in [rule][groups] {
+        # Drop vulnerability-detector events from Manager
+        if [agent][id] == "000"{
+            drop { }
+        }
+
+        # if exists, remove data.vulnerability.published field due to conflicts
+        if [data][vulnerability][published] {
+            mutate {
+                remove_field => [ "[data][vulnerability][published]" ]
+            }
+        }
+    }
+}
 output {
     elasticsearch {
         hosts => ["elasticsearch:9200"]


### PR DESCRIPTION
Hello team,

This PR adds to the Logstash image a new filter in the pipeline to avoid errors produced by the data published field of vulnerability detector. 

Best regards,

Alfonso Ruiz-Bravo