### PR TITLE
Fix S3 plugin installation in Elasticsearch

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,6 +1,7 @@
 # Wazuh Docker Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 ARG ELASTIC_VERSION=7.5.1
 FROM docker.elastic.co/elasticsearch/elasticsearch:${ELASTIC_VERSION}
+ARG ELASTIC_VERSION
 ARG S3_PLUGIN_URL="https://artifacts.elastic.co/downloads/elasticsearch-plugins/repository-s3/repository-s3-${ELASTIC_VERSION}.zip"
 
 ENV ELASTICSEARCH_URL="http://elasticsearch:9200"
@@ -42,7 +43,7 @@ COPY --chown=elasticsearch:elasticsearch ./config/load_settings.sh ./
 
 RUN chmod +x ./load_settings.sh
 
-RUN ${bin/elasticsearch-plugin install --batch S3_PLUGIN_URL}
+RUN bin/elasticsearch-plugin install --batch $S3_PLUGIN_URL
 
 COPY config/configure_s3.sh ./config/configure_s3.sh
 RUN chmod 755 ./config/configure_s3.sh


### PR DESCRIPTION
Hello,

This PR fixes two problems I had with the installation of the S3 plugin.
- The first one is related to [ARG before FROM](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact) which is not taken into account in the rest of the Dockerfile.
- The second one was related to `${bin/elasticsearch-plugin install --batch S3_PLUGIN_URL}` which did nothing