### PR TITLE
Use batch mode on htpasswd

### DIFF
--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -30,14 +30,14 @@ if [ ! -f /etc/nginx/conf.d/kibana.htpasswd ]; then
     do
       IFS=':' read -r -a credentials <<< "${users[index]}"
       if [ $index -eq 0 ]; then
-        echo ${credentials[1]}|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd ${credentials[0]} >/dev/null
+        htpasswd -b -c /etc/nginx/conf.d/kibana.htpasswd ${credentials[0]} ${credentials[1]} >/dev/null
       else
-        echo ${credentials[1]}|htpasswd -i /etc/nginx/conf.d/kibana.htpasswd  ${credentials[0]} >/dev/null
+        htpasswd -b /etc/nginx/conf.d/kibana.htpasswd  ${credentials[0]} ${credentials[1]} >/dev/null
       fi
     done
   else
     # NGINX_PWD and NGINX_NAME are declared in nginx/Dockerfile 
-    echo $NGINX_PWD|htpasswd -i -c /etc/nginx/conf.d/kibana.htpasswd $NGINX_NAME >/dev/null
+    htpasswd -b -c /etc/nginx/conf.d/kibana.htpasswd $NGINX_NAME $NGINX_PWD >/dev/null
   fi
 else
   echo "Kibana credentials already configured"


### PR DESCRIPTION
This PR fixes #305 

The `htpasswd` utility supports batch mode `-b` which takes username and password as CLI arguments so there's no need to use a pipe.

This change was already tested locally.