### PR TITLE
Add trap for sbin my init 

### DIFF
--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -10,4 +10,7 @@ done
 # Start Wazuh Server.
 ##############################################################################
 
-/sbin/my_init 
+function init_process(){
+  /sbin/my_init 
+}
+trap "init_process; exit" SIGINT SIGTERM

--- a/wazuh/config/entrypoint.sh
+++ b/wazuh/config/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Wazuh Docker Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 
+# Trap to kill container if it is necessary.
+trap "exit" SIGINT SIGTERM
 # It will run every .sh script located in entrypoint-scripts folder in lexicographical order
 for script in `ls /entrypoint-scripts/*.sh | sort -n`; do
   bash "$script"
@@ -10,7 +12,4 @@ done
 # Start Wazuh Server.
 ##############################################################################
 
-function init_process(){
-  /sbin/my_init 
-}
-trap "init_process; exit" SIGINT SIGTERM
+/sbin/my_init 


### PR DESCRIPTION
Hello team,

This PR adds a trap to be able to kill the initial process of the wazuh container, in order to manage errors in the start of the container. 

Best regards,

Alfonso Ruiz-Bravo