### PR TITLE
Create .wazuh index before setting the API credentials

### DIFF
--- a/elasticsearch/config/35-entrypoint_load_settings.sh
+++ b/elasticsearch/config/35-entrypoint_load_settings.sh
@@ -165,6 +165,16 @@ echo "LOAD SETTINGS - Setting API credentials into Wazuh APP"
 CONFIG_CODE=$(curl -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/_doc/1513629884013 ${auth})
 
 if [ "x$CONFIG_CODE" != "x200" ]; then
+
+  curl -s ${auth} -X PUT "$el_url/.wazuh/?pretty" -H 'Content-Type: application/json' -d'
+  {
+    "settings" : {
+          "number_of_shards" : 1,
+          "number_of_replicas" : 0,
+          "auto_expand_replicas": "0-1"
+    }
+  }
+  '
   curl -s -XPOST $el_url/.wazuh/_doc/1513629884013 ${auth} -H 'Content-Type: application/json' -d'
   {
     "api_user": "'"$API_USER_Q"'",


### PR DESCRIPTION
Hi team!!!

This PR creates the _.wazuh_ index with **0 replicas** before setting the Wazuh API credentials to avoid the cluster state switching to yellow in Elasticseaerch single-node clusters.

Best regards,
Mayte Ariza