### PR TITLE
Improve Wazuh image: overwriting and removing files

### DIFF
--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -110,6 +110,7 @@ COPY config/03-config_filebeat.sh /entrypoint-scripts/03-config_filebeat.sh
 COPY config/20-ossec-configuration.sh /entrypoint-scripts/20-ossec-configuration.sh
 COPY config/25-backups.sh /entrypoint-scripts/25-backups.sh
 COPY config/35-remove_credentials_file.sh /entrypoint-scripts/35-remove_credentials_file.sh
+COPY config/85-save_wazuh_version.sh /entrypoint-scripts/85-save_wazuh_version.sh
 RUN chmod 755 /entrypoint.sh && \
     chmod 755 /entrypoint-scripts/00-decrypt_credentials.sh && \
     chmod 755 /entrypoint-scripts/01-wazuh.sh && \
@@ -117,7 +118,8 @@ RUN chmod 755 /entrypoint.sh && \
     chmod 755 /entrypoint-scripts/03-config_filebeat.sh && \
     chmod 755 /entrypoint-scripts/20-ossec-configuration.sh && \
     chmod 755 /entrypoint-scripts/25-backups.sh && \
-    chmod 755 /entrypoint-scripts/35-remove_credentials_file.sh
+    chmod 755 /entrypoint-scripts/35-remove_credentials_file.sh && \
+    chmod 755 /entrypoint-scripts/85-save_wazuh_version.sh
 
 # Workaround. 
 # Issues: Wazuh-api

--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -126,7 +126,7 @@ apply_exclusion_data() {
 
 remove_data_files() {
   for del_file in "${PERMANENT_DATA_DEL[@]}"; do
-    if [ -e ${del_file[0]} ]
+    if [ $(ls ${del_file} 2> /dev/null | wc -l) -ne 0 ]
     then 
       print "Removing ${del_file}"
       exec_cmd "rm ${del_file}"

--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -35,10 +35,10 @@ exec_cmd_stdout() {
 ##############################################################################
 # Check_update
 # This function considers the following cases:
-# - If /var/ossec/etc/ossec-init.conf does not exist -> There is no data in the EBS. First time deploying Wazuh 
-# - If /var/ossec/etc/VERSION does not exist -> Update (The previous version was prior to 3.11.5) 
-# - If both files exist: different Wazuh version -> Update (The previous version was later to 3.11.5)
-# - If both files exist: the same Wazuh version -> Current version matches the upcoming one
+# - If /var/ossec/etc/ossec-init.conf does not exist -> Action Nothing. There is no data in the EBS. First time deploying Wazuh
+# - If /var/ossec/etc/VERSION does not exist -> Action: Update. The previous version was prior to 3.11.5.
+# - If both files exist: different Wazuh version -> Action: Update. The previous version is older than the current one.
+# - If both files exist: the same Wazuh version -> Acton: Nothing. Same Wazuh version.
 ##############################################################################
 
 check_update() {
@@ -46,11 +46,11 @@ check_update() {
   then
     if [ -e /var/ossec/etc/VERSION ]
     then
-      current_version=$(cat /var/ossec/etc/VERSION | grep -i version | cut -d'"' -f2)
+      previous_version=$(cat /var/ossec/etc/VERSION | grep -i version | cut -d'"' -f2)
+      echo "Previous version: $previous_version"
+      current_version=$(cat ${WAZUH_INSTALL_PATH}/data_tmp/permanent/var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
       echo "Current version: $current_version"
-      upcoming_version=$(cat ${WAZUH_INSTALL_PATH}/data_tmp/permanent/var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
-      echo "Upcoming version: $upcoming_version"
-      if [ $current_version == $upcoming_version ]
+      if [ $previous_version == $current_version ]
       then
         echo "Same Wazuh version in the EBS and image"
         return 0

--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -35,8 +35,9 @@ check_update() {
   if [ -e /var/ossec/etc/ossec-init.conf ]
   then
     current_version=$(cat /var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
+    echo "Current version: $current_version"
     upcoming_version=$(cat ${WAZUH_INSTALL_PATH}/data_tmp/permanent/var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
-
+    echo "Upcoming version: $upcoming_version"
     if [  $current_version == $upcoming_version ]
     then
       echo "Same Wazuh version in the EBS and image"

--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -37,8 +37,8 @@ exec_cmd_stdout() {
 # This function considers the following cases:
 # - If /var/ossec/etc/ossec-init.conf does not exist -> There is no data in the EBS. First time deploying Wazuh 
 # - If /var/ossec/etc/VERSION does not exist -> Update (The previous version was prior to 3.11.5) 
-# - If both files exist with different Wazuh versions -> Update (The previous version was later to 3.11.5)
-# - If both files exist with the same Wazuh versions -> Current version matches the upcoming one
+# - If both files exist: different Wazuh version -> Update (The previous version was later to 3.11.5)
+# - If both files exist: the same Wazuh version -> Current version matches the upcoming one
 ##############################################################################
 
 check_update() {

--- a/wazuh/config/01-wazuh.sh
+++ b/wazuh/config/01-wazuh.sh
@@ -31,19 +31,35 @@ exec_cmd_stdout() {
   eval $1 2>&1 || error_and_exit "$1"
 }
 
+
+##############################################################################
+# Check_update
+# This function considers the following cases:
+# - If /var/ossec/etc/ossec-init.conf does not exist -> There is no data in the EBS. First time deploying Wazuh 
+# - If /var/ossec/etc/VERSION does not exist -> Update (The previous version was prior to 3.11.5) 
+# - If both files exist with different Wazuh versions -> Update (The previous version was later to 3.11.5)
+# - If both files exist with the same Wazuh versions -> Current version matches the upcoming one
+##############################################################################
+
 check_update() {
   if [ -e /var/ossec/etc/ossec-init.conf ]
   then
-    current_version=$(cat /var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
-    echo "Current version: $current_version"
-    upcoming_version=$(cat ${WAZUH_INSTALL_PATH}/data_tmp/permanent/var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
-    echo "Upcoming version: $upcoming_version"
-    if [  $current_version == $upcoming_version ]
+    if [ -e /var/ossec/etc/VERSION ]
     then
-      echo "Same Wazuh version in the EBS and image"
-      return 0
+      current_version=$(cat /var/ossec/etc/VERSION | grep -i version | cut -d'"' -f2)
+      echo "Current version: $current_version"
+      upcoming_version=$(cat ${WAZUH_INSTALL_PATH}/data_tmp/permanent/var/ossec/etc/ossec-init.conf | grep -i version | cut -d'"' -f2)
+      echo "Upcoming version: $upcoming_version"
+      if [ $current_version == $upcoming_version ]
+      then
+        echo "Same Wazuh version in the EBS and image"
+        return 0
+      else
+        echo "Different Wazuh version: Update"
+        return 1
+      fi
     else
-      echo "Different Wazuh version: Update"
+      echo "Previous version prior to 3.11.5: Update"
       return 1
     fi
   else

--- a/wazuh/config/85-save_wazuh_version.sh
+++ b/wazuh/config/85-save_wazuh_version.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+
+# Copy /var/ossec/etc/ossec-init.conf contents in /var/ossec/etc/VERSION to be able to check the previous Wazuh version in pod.
+
+cat /var/ossec/etc/ossec-init.conf > /var/ossec/etc/VERSION

--- a/wazuh/config/85-save_wazuh_version.sh
+++ b/wazuh/config/85-save_wazuh_version.sh
@@ -2,5 +2,5 @@
 # Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
 
 # Copy /var/ossec/etc/ossec-init.conf contents in /var/ossec/etc/VERSION to be able to check the previous Wazuh version in pod.
-
+echo "Adding Wazuh version to /var/ossec/etc/VERSION"
 cat /var/ossec/etc/ossec-init.conf > /var/ossec/etc/VERSION

--- a/wazuh/config/permanent_data.env
+++ b/wazuh/config/permanent_data.env
@@ -57,7 +57,7 @@ PERMANENT_DATA_EXCP[((i++))]="/var/ossec/queue/vulnerabilities/dictionaries/cpe_
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/queue/vulnerabilities/dictionaries/msu.json.gz"
 export PERMANENT_DATA_EXCP
 
-# Files mounted in a volume that should be deleted 
+# Files mounted in a volume that should be deleted when updating
 i=0
 PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/db/.template.db"
 PERMANENT_DATA_DEL[((i++))]="/var/ossec/var/db/global.db*"

--- a/wazuh/config/permanent_data.env
+++ b/wazuh/config/permanent_data.env
@@ -53,9 +53,17 @@ PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/oscap/content/cve-ubuntu-xenial-
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/oscap/content/ssg-debian-8-ds.xml"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/oscap/content/ssg-ubuntu-1404-ds.xml"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/oscap/content/ssg-ubuntu-1604-ds.xml"
+PERMANENT_DATA_EXCP[((i++))]="/var/ossec/queue/vulnerabilities/dictionaries/cpe_helper.json"
+PERMANENT_DATA_EXCP[((i++))]="/var/ossec/queue/vulnerabilities/dictionaries/msu.json.gz"
 export PERMANENT_DATA_EXCP
 
 # Files mounted in a volume that should be deleted 
 i=0
 PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/db/.template.db"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/var/db/global.db*"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/var/db/.profile.db*"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/var/db/.template.db*"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/var/db/agents/*"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/wodles/cve.db"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/vulnerabilities/cve.db"
 export PERMANENT_DATA_DEL


### PR DESCRIPTION
Hi team!!

This PR improves the Wazuh image to solve some issues that may appear when updating the environment:

- It **adds** the following files in `PERMANENT_DATA_EXCP`:
  - /var/ossec/queue/vulnerabilities/dictionaries/cpe_helper.json
  - /var/ossec/queue/vulnerabilities/dictionaries/msu.json.gz

- It **adds** the following files in `PERMANENT_DATA_DEL`:
  - /var/ossec/var/db/global.db*
  - /var/ossec/var/db/.profile.db*
  - /var/ossec/var/db/.template.db*
  - /var/ossec/var/db/agents/*
  - /var/ossec/wodles/cve.db
  - /var/ossec/queue/vulnerabilities/cve.db

- We have added a new file, `/var/ossec/etc/VERSION`, in order to check the previous Wazuh version installed in the pod.


Best regards,
Mayte Ariza