### PR TITLE
Add /var/ossec/var/db to permanent data

### DIFF
--- a/wazuh/config/permanent_data.env
+++ b/wazuh/config/permanent_data.env
@@ -10,6 +10,7 @@ PERMANENT_DATA[((i++))]="/var/ossec/active-response/bin"
 PERMANENT_DATA[((i++))]="/var/ossec/wodles"
 PERMANENT_DATA[((i++))]="/etc/filebeat"
 PERMANENT_DATA[((i++))]="/etc/postfix"
+PERMANENT_DATA[((i++))]="/var/ossec/var/db"
 export PERMANENT_DATA
 
 # Files mounted in a volume that should not be permanent
@@ -55,6 +56,7 @@ PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/oscap/content/ssg-ubuntu-1404-ds
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/oscap/content/ssg-ubuntu-1604-ds.xml"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/queue/vulnerabilities/dictionaries/cpe_helper.json"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/queue/vulnerabilities/dictionaries/msu.json.gz"
+PERMANENT_DATA_EXCP[((i++))]="/var/ossec/var/db/mitre.db"
 export PERMANENT_DATA_EXCP
 
 # Files mounted in a volume that should be deleted when updating


### PR DESCRIPTION
Hi team!!!

This PR adds `/var/ossec/var/db` path to PERMANENT_DATA variable in order to keep **mitre.db** when mounting the path `/var/ossec/var/db` .

Best regards,
Mayte Ariza