### PR TITLE
Adding blocks for port 80 and 443 to fix bug for too many redirects

### DIFF
--- a/nginx/config/entrypoint.sh
+++ b/nginx/config/entrypoint.sh
@@ -52,6 +52,9 @@ if [ "x${KIBANA_HOST}" = "x" ]; then
 fi
 
 echo "Configuring NGINX"
+
+
+if [ "${NGINX_PORT}" = "443" ]; then
 cat > /etc/nginx/conf.d/default.conf <<EOF
 server {
     listen 80;
@@ -74,5 +77,24 @@ server {
     }
 }
 EOF
+fi
+
+if [ "${NGINX_PORT}" = "80" ]; then
+cat > /etc/nginx/conf.d/default.conf <<EOF
+server {
+    listen 80;
+    listen [::]:80;
+    location / {
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/conf.d/kibana.htpasswd;
+        proxy_pass http://${KIBANA_HOST}/;
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
+    }
+}
+EOF
+fi
+
 
 exec nginx -g 'daemon off;'


### PR DESCRIPTION
What was happening:
When you give nginx port to 80 in env variable `NGINX_PORT=80. `
the block below tries to redirect it back to port 80 and this too many redirects errors. 
```
server {
    listen 80;
    listen [::]:80;
    return 301 https://\$host:${NGINX_PORT}\$request_uri;
}
```
Added the blocks to serve the traffic from 80 without ssl and 443 with ssl and redirect 80 traffic to 443. 