### PR TITLE
Adapt wazuh to 3.13.1 and filebeat to 7.7.0

### DIFF
--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -2,8 +2,8 @@
 FROM phusion/baseimage:latest
 
 # Arguments
-ARG FILEBEAT_VERSION=7.7.0
-ARG WAZUH_VERSION=3.13.0-1
+ARG FILEBEAT_VERSION=7.8.0
+ARG WAZUH_VERSION=3.13.1-1
 
 # Environment variables
 ENV API_USER="foo" \
@@ -117,3 +117,4 @@ RUN chmod go-w /etc/filebeat/wazuh-template.json
 
 # Run all services
 ENTRYPOINT ["/entrypoint.sh"]
+

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -2,7 +2,7 @@
 FROM phusion/baseimage:0.10.2
 
 # Arguments
-ARG FILEBEAT_VERSION=7.8.0
+ARG FILEBEAT_VERSION=7.7.0
 ARG WAZUH_VERSION=3.13.1-1
 
 # Environment variables

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2019 Wazuh Inc. (License GPLv2)
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.10.2
 
 # Arguments
 ARG FILEBEAT_VERSION=7.8.0


### PR DESCRIPTION
Hello team,

This PR updates Wazuh original image for cloud to Wazuh 3.13.1 and filebeat to 7.8.0 for Opendistro 1.9.0.

Best regards