### PR TITLE
Add CLUSTER_NETWORK_HOST environment variable to configure network.host

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -23,6 +23,7 @@ ARG TEMPLATE_VERSION=v3.13.1
 # CLUSTER_INITIAL_MASTER_NODES set to own node by default.
 ENV ELASTIC_CLUSTER="false" \
     CLUSTER_NAME="wazuh" \
+    CLUSTER_NETWORK_HOST="0.0.0.0" \
     CLUSTER_NODE_MASTER="false" \
     CLUSTER_NODE_DATA="true" \
     CLUSTER_NODE_INGEST="true" \

--- a/elasticsearch/config/config_cluster.sh
+++ b/elasticsearch/config/config_cluster.sh
@@ -24,7 +24,7 @@ if [[ $CLUSTER_NODE_MASTER == "true" ]]; then
 # cluster.initial_master_nodes for bootstrap the cluster
 cat > $elastic_config_file << EOF
 # cluster node
-network.host: 0.0.0.0
+network.host: $CLUSTER_NETWORK_HOST
 node.name: $CLUSTER_MASTER_NODE_NAME
 node.master: $CLUSTER_NODE_MASTER
 cluster.initial_master_nodes:
@@ -39,7 +39,7 @@ remove_cluster_config $elastic_config_file
 
 cat > $elastic_config_file << EOF
 # cluster node
-network.host: 0.0.0.0
+network.host: $CLUSTER_NETWORK_HOST
 node.name: $CLUSTER_NODE_NAME
 node.master: false
 discovery.seed_hosts:


### PR DESCRIPTION
Hello,

This PR add CLUSTER_NETWORK_HOST environment variable to configure `network.host` for Elasticsearch Cluster.

Example: `CLUSTER_NETWORK_HOST=_local_,192.168.1.111`

If CLUSTER_NETWORK_HOST is not set, then 0.0.0.0.0 is used as before.

Problem:

If an Elasticsearch container can recognize multiple IP addresses, it may respond the local IP of the docker network and other Elasticseach containers(node) are not be able to join the cluster.

- Docker Host 1: elasticsearch(es01) + network_mode: host

```
  elasticsearch:
    image: wazuh/wazuh-elasticsearch:3.13.1_7.8.0
    hostname: elasticsearch
    extra_hosts:
      - "elasticsearch:192.168.1.111"
      - "es01:192.168.1.111"
      - "es02:192.168.1.112"
    restart: always
    ports:
      - "9200:9200"
      - "9300:9300"
    environment:
      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
      - ELASTIC_CLUSTER=true
      - CLUSTER_NETWORK_HOST=_local_,192.168.1.111
      - CLUSTER_NODE_MASTER=true
      - CLUSTER_MASTER_NODE_NAME=elasticsearch
    ulimits:
      memlock:
        soft: -1
        hard: -1
    mem_limit: 2g
    network_mode: host
```

- Docker Host 2: es02 + network_mode: host

```
  es02:
    image: wazuh/wazuh-elasticsearch:3.13.1_7.8.0
    hostname: es02
    extra_hosts:
      - "elasticsearch:192.168.1.111"
      - "es01:192.168.1.111"
      - "es02:192.168.1.112"
    restart: always
    ports:
      - "9200:9200"
      - "9300:9300"
    environment:
      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
      - ELASTIC_CLUSTER=true
      - CLUSTER_NETWORK_HOST=_local_,192.168.1.112
      - CLUSTER_MASTER_NODE_NAME=elasticsearch
      - CLUSTER_NODE_NAME=es02
    ulimits:
      memlock:
        soft: -1
        hard: -1
    mem_limit: 2g
    network_mode: host
```

In the following case, I expect elasticsearch(es01) to respond with 192.168.1.111, but it responds with 172.25.0.1. Therefore, es02 will fail to join the cluster.

Docker Host1 status:

```bash
# ip a | grep "inet "
    inet 127.0.0.1/8 scope host lo
    inet 192.168.1.111/16 brd 192.168.255.255 scope global noprefixroute br0
    inet 172.25.0.1/24 brd 172.25.0.255 scope global br-15fe5c2fd2dc
    inet 172.17.0.1/16 brd 172.17.255.255 scope global docker0

# curl http://localhost:9200/_cat/nodes?v
ip         heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
172.25.0.1           17          93  34    2.19    2.07     1.85 dilmrt    *      elasticsearch
```

es02 log:

`followup connection failed.`

```
es02_1  | {"type": "server", "timestamp": "2020-08-23T02:38:35,411Z", "level": "WARN", "component": "o.e.d.HandshakingTransportAddressConnector", "cluster.name": "elasticsearch", "node.name": "es02", "message": "[connectToRemoteMasterNode[192.168.1.111:9300]] completed handshake with [{elasticsearch}{5MsimsjLTBS2ms_AImfQ_A}{nfEq1iyyQHiOIuNX4HVenA}{172.25.0.1}{172.25.0.1:9300}{dilmrt}{ml.machine_memory=6442450944, ml.max_open_jobs=20, xpack.installed=true, transform.node=true}] but followup connection failed",
```

After applying this patch:

- Docker Host1: elasticsearch(es01) + network_mode: host + `CLUSTER_NETWORK_HOST=_local_,192.168.1.111`

```bash
# curl http://localhost:9200/_cat/nodes?v
ip            heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
192.168.1.111           15          94  18    1.92    2.06     1.83 dilmrt    *      elasticsearch
```

And es02 successfully joins the cluster.

```bash
# curl http://localhost:9200/_cat/nodes?v
ip            heap.percent ram.percent cpu load_1m load_5m load_15m node.role master name
192.168.1.112            8          93   0    0.19    0.12     0.07 dilrt     -      es02
192.168.1.111           16          94  18    2.04    1.66     1.47 dilmrt    *      elasticsearch
```
