### PR TITLE
Fix filebeat installation

### DIFF
--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -76,5 +76,8 @@ RUN chmod +x /etc/service/wazuh-api/run && \
 ADD https://raw.githubusercontent.com/wazuh/wazuh/$TEMPLATE_VERSION/extensions/elasticsearch/7.x/wazuh-template.json /etc/filebeat
 RUN chmod go-w /etc/filebeat/wazuh-template.json
 
+ARG WAZUH_FILEBEAT_MODULE="wazuh-filebeat-0.1.tar.gz"
+RUN curl -s https://packages.wazuh.com/3.x/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
+
 # Run all services
 ENTRYPOINT ["/entrypoint.sh"]

--- a/wazuh/Dockerfile
+++ b/wazuh/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.10.2
 
 ARG FILEBEAT_VERSION=7.8.0
 

--- a/wazuh/config/01-config_filebeat.sh
+++ b/wazuh/config/01-config_filebeat.sh
@@ -3,16 +3,8 @@
 
 set -e
 
-WAZUH_FILEBEAT_MODULE=wazuh-filebeat-0.1.tar.gz
-
 # Modify the output to Elasticsearch if th ELASTICSEARCH_URL is set
 if [ "$ELASTICSEARCH_URL" != "" ]; then
   >&2 echo "Customize Elasticsearch ouput IP."
   sed -i 's|http://elasticsearch:9200|'$ELASTICSEARCH_URL'|g' /etc/filebeat/filebeat.yml
 fi
-
-# Install Wazuh Filebeat Module
-
-curl -s "https://packages.wazuh.com/3.x/filebeat/${WAZUH_FILEBEAT_MODULE}" | tar -xvz -C /usr/share/filebeat/module
-mkdir -p /usr/share/filebeat/module/wazuh
-chmod 755 -R /usr/share/filebeat/module/wazuh


### PR DESCRIPTION
This PR fixes #374 

Filebeat module is now installed on build stage.

Also pinned the phusion/baseimage to version `0.10.2` since the tag `latest` was deleted recently.