### PR TITLE
Read archives events in Filebeat

### DIFF
--- a/wazuh/config/filebeat_to_logstash.yml
+++ b/wazuh/config/filebeat_to_logstash.yml
@@ -6,8 +6,6 @@ filebeat:
   - type: log
     paths:
       - "/var/ossec/logs/alerts/alerts.json"
-  #   fields:
-  #     wazuh_log_file: "alerts"
   # - type: log
   #   paths:
   #     - "/var/ossec/logs/archives/archives.json"

--- a/wazuh/config/filebeat_to_logstash.yml
+++ b/wazuh/config/filebeat_to_logstash.yml
@@ -5,7 +5,14 @@ filebeat:
  inputs:
   - type: log
     paths:
-     - "/var/ossec/logs/alerts/alerts.json"
+      - "/var/ossec/logs/alerts/alerts.json"
+  #   fields:
+  #     wazuh_log_file: "alerts"
+  # - type: log
+  #   paths:
+  #     - "/var/ossec/logs/archives/archives.json"
+  #   fields:
+  #     wazuh_log_file: "archives"
 
 output:
  logstash:


### PR DESCRIPTION
Hello team,

This PR allows read archives.json events in Filebeat. Option disabled by default. 

Regards