### PR TITLE
fix max file descriptors error on docker-compse

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,9 @@ services:
       memlock:
         soft: -1
         hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
     mem_limit: 2g
 
   kibana:


### PR DESCRIPTION
When using the docker-compose file, elasticsearch fails to start with the following error: 
```
elasticsearch_1  | [1]: max file descriptors [4096] for elasticsearch process is too low, increase to at least [65535]
```

Adding 
```      
nofile:
        soft: 65536
        hard: 65536
```

to the elasticsearch ulimit section fixes the issue.