### PR TITLE
Updating Wazuh cluster key dynamically

### DIFF
--- a/wazuh/config/00-wazuh.sh
+++ b/wazuh/config/00-wazuh.sh
@@ -123,6 +123,9 @@ function ossec_shutdown(){
 ##############################################################################
 sed -i 's/<node_name>to_be_replaced_by_hostname<\/node_name>/<node_name>'"${HOSTNAME}"'<\/node_name>/g' ${WAZUH_INSTALL_PATH}/etc/ossec.conf
 
+# Setting Wazuh cluster key
+sed -i 's/<key>to_be_replaced_by_cluster_key<\/key>/<key>'"${WAZUH_CLUSTER_KEY}"'<\/key>/g' ${WAZUH_INSTALL_PATH}/etc/ossec.conf
+
 # Trap exit signals and do a proper shutdown
 trap "ossec_shutdown; exit" SIGINT SIGTERM
 


### PR DESCRIPTION
We want to use Kubernetes secrets for passing all Wazuh credentials (Issue: https://github.com/wazuh/wazuh-kubernetes/issues/29)
For this I have tweaked one of the entrypoint scripts to dynamically passed the key from Kubernetes pod spec (https://github.com/wazuh/wazuh-kubernetes/pull/108).

### Changes
- Replacing the placeholder for cluster key in ossec.conf with an environment variable `WAZUH_CLUSTER_KEY`