### PR TITLE
Add images compatible with xpack

### DIFF
--- a/generate-elasticsearch-certs.yml
+++ b/generate-elasticsearch-certs.yml
@@ -1,8 +1,8 @@
 version: '2.2'
 
 services:
-  create_certs:
-    container_name: create_certs
+  generator:
+    container_name: generator
     image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
     command: >
       bash -c '

--- a/generate-elasticsearch-certs.yml
+++ b/generate-elasticsearch-certs.yml
@@ -1,0 +1,17 @@
+version: '2.2'
+
+services:
+  create_certs:
+    container_name: create_certs
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    command: >
+      bash -c '
+        if [[ ! -f config/certificates/bundle.zip ]]; then
+          bin/elasticsearch-certutil cert --silent --pem --in config/certificates/instances.yml -out config/certificates/bundle.zip;
+          unzip config/certificates/bundle.zip -d config/certificates/;
+        fi;
+        chown -R 1000:0 /certs
+      '
+    user: "0"
+    working_dir: /usr/share/elasticsearch
+    volumes: ['./xpack:/usr/share/elasticsearch/config/certificates']

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -61,6 +61,5 @@ RUN chmod +x ./kibana_settings.sh
 
 COPY --chown=kibana:kibana ./config/xpack_config.sh ./
 RUN chmod +x ./xpack_config.sh
-RUN ./xpack_config.sh
 
 ENTRYPOINT ./entrypoint.sh

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,6 +1,5 @@
 # Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
-ARG KIBANA_IMAGE=docker.elastic.co/kibana/kibana:7.9.3
-FROM ${KIBANA_IMAGE}
+FROM docker.elastic.co/kibana/kibana:7.9.3
 USER kibana
 ARG ELASTIC_VERSION=7.9.3
 ARG WAZUH_VERSION=4.0.3

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,8 +1,8 @@
-# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+# Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 FROM docker.elastic.co/kibana/kibana:7.9.3
 USER kibana
 ARG ELASTIC_VERSION=7.9.3
-ARG WAZUH_VERSION=4.0.3
+ARG WAZUH_VERSION=4.0.4
 ARG WAZUH_APP_VERSION="${WAZUH_VERSION}_${ELASTIC_VERSION}"
 
 WORKDIR /usr/share/kibana

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -50,6 +50,8 @@ RUN NODE_OPTIONS="--max-old-space-size=2048" /usr/local/bin/kibana-docker --opti
 COPY --chown=kibana:kibana config/entrypoint.sh ./entrypoint.sh
 RUN chmod 755 ./entrypoint.sh
 
+RUN printf "\nserver.defaultRoute: /app/wazuh\n" >> /usr/share/kibana/config/kibana.yml
+
 COPY --chown=kibana:kibana ./config/wazuh.yml /usr/share/kibana/optimize/wazuh/config/wazuh.yml
 COPY --chown=kibana:kibana ./config/wazuh_app_config.sh ./
 RUN chmod +x ./wazuh_app_config.sh

--- a/kibana/Dockerfile
+++ b/kibana/Dockerfile
@@ -1,0 +1,65 @@
+# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+ARG KIBANA_IMAGE=docker.elastic.co/kibana/kibana:7.9.3
+FROM ${KIBANA_IMAGE}
+USER kibana
+ARG ELASTIC_VERSION=7.9.3
+ARG WAZUH_VERSION=4.0.3
+ARG WAZUH_APP_VERSION="${WAZUH_VERSION}_${ELASTIC_VERSION}"
+
+WORKDIR /usr/share/kibana
+RUN ./bin/kibana-plugin install https://packages.wazuh.com/4.x/ui/kibana/wazuh_kibana-${WAZUH_APP_VERSION}-1.zip
+
+ENV PATTERN="" \
+    CHECKS_PATTERN="" \
+    CHECKS_TEMPLATE="" \
+    CHECKS_API="" \
+    CHECKS_SETUP="" \
+    EXTENSIONS_PCI="" \
+    EXTENSIONS_GDPR="" \
+    EXTENSIONS_HIPAA="" \
+    EXTENSIONS_NIST="" \
+    EXTENSIONS_TSC="" \
+    EXTENSIONS_AUDIT="" \
+    EXTENSIONS_OSCAP="" \
+    EXTENSIONS_CISCAT="" \
+    EXTENSIONS_AWS="" \
+    EXTENSIONS_GCP="" \
+    EXTENSIONS_VIRUSTOTAL="" \
+    EXTENSIONS_OSQUERY="" \
+    EXTENSIONS_DOCKER="" \
+    APP_TIMEOUT="" \
+    API_SELECTOR="" \
+    IP_SELECTOR="" \
+    IP_IGNORE="" \
+    WAZUH_MONITORING_ENABLED="" \
+    WAZUH_MONITORING_FREQUENCY="" \
+    WAZUH_MONITORING_SHARDS="" \
+    WAZUH_MONITORING_REPLICAS="" \
+    ADMIN_PRIVILEGES="" \
+    XPACK_CANVAS="true" \
+    XPACK_LOGS="true"   \
+    XPACK_INFRA="true"  \
+    XPACK_ML="true" \
+    XPACK_DEVTOOLS="true"   \
+    XPACK_MONITORING="true" \
+    XPACK_APM="true"
+
+WORKDIR /
+USER kibana
+RUN NODE_OPTIONS="--max-old-space-size=2048" /usr/local/bin/kibana-docker --optimize
+
+COPY --chown=kibana:kibana config/entrypoint.sh ./entrypoint.sh
+RUN chmod 755 ./entrypoint.sh
+
+COPY --chown=kibana:kibana ./config/wazuh.yml /usr/share/kibana/optimize/wazuh/config/wazuh.yml
+COPY --chown=kibana:kibana ./config/wazuh_app_config.sh ./
+RUN chmod +x ./wazuh_app_config.sh
+
+COPY --chown=kibana:kibana ./config/kibana_settings.sh ./
+RUN chmod +x ./kibana_settings.sh
+
+COPY --chown=kibana:kibana ./config/xpack_config.sh ./
+RUN chmod +x ./xpack_config.sh
+RUN ./xpack_config.sh
+
+ENTRYPOINT ./entrypoint.sh

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -13,10 +13,10 @@ else
   export el_url="${ELASTICSEARCH_URL}"
 fi
 
-if [[ ${ENABLED_XPACK} != "true" || "x${ELASTICSEARCH_USERNAME}" = "x" || "x${ELASTICSEARCH_PASSWORD}" = "x" ]]; then
-  auth=""
+if [[ ${ENABLED_SECURITY} == "false" || "x${ELASTICSEARCH_USERNAME}" = "x" || "x${ELASTICSEARCH_PASSWORD}" = "x" ]]; then
+  export auth=""
 else
-  auth="--user ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
+  export auth="--user ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD} -k"
 fi
 
 until curl -XGET $el_url ${auth}; do

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+
+set -e
+
+##############################################################################
+# Waiting for elasticsearch
+##############################################################################
+
+if [ "x${ELASTICSEARCH_URL}" = "x" ]; then
+  export el_url="http://elasticsearch:9200"
+else
+  export el_url="${ELASTICSEARCH_URL}"
+fi
+
+if [[ ${ENABLED_XPACK} != "true" || "x${ELASTICSEARCH_USERNAME}" = "x" || "x${ELASTICSEARCH_PASSWORD}" = "x" ]]; then
+  auth=""
+else
+  auth="--user ${ELASTICSEARCH_USERNAME}:${ELASTICSEARCH_PASSWORD}"
+fi
+
+until curl -XGET $el_url ${auth}; do
+  >&2 echo "Elastic is unavailable - sleeping"
+  sleep 5
+done
+
+sleep 2
+
+>&2 echo "Elasticsearch is up."
+
+
+##############################################################################
+# Waiting for wazuh alerts template
+##############################################################################
+
+strlen=0
+
+while [[ $strlen -eq 0 ]]
+do
+  template=$(curl ${auth} $el_url/_cat/templates/wazuh -s)
+  strlen=${#template}
+  >&2 echo "Wazuh alerts template not loaded - sleeping."
+  sleep 2
+done
+
+sleep 2
+
+>&2 echo "Wazuh alerts template is loaded."
+
+./xpack_config.sh
+
+./wazuh_app_config.sh
+
+sleep 5
+
+./kibana_settings.sh &
+
+sleep 2
+
+/usr/local/bin/kibana-docker

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+# Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 
 set -e
 

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -37,12 +37,6 @@ if [ "$XPACK_SECURITY_ENABLED" != "" ]; then
     echo "xpack.security.enabled: $XPACK_SECURITY_ENABLED" >> /usr/share/kibana/config/kibana.yml
 fi
 
-if [ "$KIBANA_IP" != "" ]; then
-  kibana_ip="$KIBANA_IP"
-else
-  kibana_ip="kibana"
-fi
-
 # Add auth headers if required
 if [ "$ELASTICSEARCH_USERNAME" != "" ] && [ "$ELASTICSEARCH_PASSWORD" != "" ]; then
     curl_auth="-u $ELASTICSEARCH_USERNAME:$ELASTICSEARCH_PASSWORD"

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+# Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 
 WAZUH_MAJOR=4
 

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+
+WAZUH_MAJOR=4
+
+##############################################################################
+# Wait for the Kibana API to start. It is necessary to do it in this container
+# because the others are running Elastic Stack and we can not interrupt them.
+#
+# The following actions are performed:
+#
+# Add the wazuh alerts index as default.
+# Set the Discover time interval to 24 hours instead of 15 minutes.
+# Do not ask user to help providing usage statistics to Elastic.
+##############################################################################
+
+##############################################################################
+# Customize elasticsearch ip
+##############################################################################
+sed -i "s|elasticsearch.hosts:.*|elasticsearch.hosts: $el_url|g" /usr/share/kibana/config/kibana.yml
+
+# If KIBANA_INDEX was set, then change the default index in kibana.yml configuration file. If there was an index, then delete it and recreate.
+if [ "$KIBANA_INDEX" != "" ]; then
+  if grep -q 'kibana.index' /usr/share/kibana/config/kibana.yml; then
+    sed -i '/kibana.index/d' /usr/share/kibana/config/kibana.yml
+  fi
+    echo "kibana.index: $KIBANA_INDEX" >> /usr/share/kibana/config/kibana.yml
+fi
+
+if [ "$XPACK_SECURITY_ENABLED" != "" ]; then
+  if grep -q 'xpack.security.enabled' /usr/share/kibana/config/kibana.yml; then
+    sed -i '/xpack.security.enabled/d' /usr/share/kibana/config/kibana.yml
+  fi
+    echo "xpack.security.enabled: $XPACK_SECURITY_ENABLED" >> /usr/share/kibana/config/kibana.yml
+fi
+
+if [ "$KIBANA_IP" != "" ]; then
+  kibana_ip="$KIBANA_IP"
+else
+  kibana_ip="kibana"
+fi
+
+# Add auth headers if required
+if [ "$ELASTICSEARCH_USERNAME" != "" ] && [ "$ELASTICSEARCH_PASSWORD" != "" ]; then
+    curl_auth="-u $ELASTICSEARCH_USERNAME:$ELASTICSEARCH_PASSWORD"
+fi
+
+while [[ "$(curl $curl_auth -XGET -I  -s -o /dev/null -w ''%{http_code}'' kibana:5601/status)" != "200" ]]; do
+  echo "Waiting for Kibana API. Sleeping 5 seconds"
+  sleep 5
+done
+
+
+
+# Prepare index selection.
+echo "Kibana API is running"
+
+default_index="/tmp/default_index.json"
+
+cat > ${default_index} << EOF
+{
+  "changes": {
+    "defaultIndex": "wazuh-alerts-${WAZUH_MAJOR}.x-*"
+  }
+}
+EOF
+
+sleep 5
+# Add the wazuh alerts index as default.
+curl ${auth} -POST -k https://127.0.0.1:5601/api/kibana/settings -H "Content-Type: application/json" -H "kbn-xsrf: true" -d@${default_index}
+rm -f ${default_index}
+
+sleep 5
+# Configuring Kibana TimePicker.
+curl ${auth} -POST -k "https://127.0.0.1:5601/api/kibana/settings" -H "Content-Type: application/json" -H "kbn-xsrf: true" -d \
+'{"changes":{"timepicker:timeDefaults":"{\n  \"from\": \"now-12h\",\n  \"to\": \"now\",\n  \"mode\": \"quick\"}"}}'
+
+sleep 5
+# Do not ask user to help providing usage statistics to Elastic
+curl -POST "http://$kibana_ip:5601/api/telemetry/v2/optIn" -H "Content-Type: application/json" -H "kbn-xsrf: true" -d '{"enabled":false}'
+
+echo "End settings"

--- a/kibana/config/wazuh.yml
+++ b/kibana/config/wazuh.yml
@@ -1,0 +1,162 @@
+---
+#
+# Wazuh app - App configuration file
+# Copyright (C) 2015-2020 Wazuh, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Find more information about this on the LICENSE file.
+#
+# ======================== Wazuh app configuration file ========================
+#
+# Please check the documentation for more information on configuration options:
+# https://documentation.wazuh.com/current/installation-guide/index.html
+#
+# Also, you can check our repository:
+# https://github.com/wazuh/wazuh-kibana-app
+#
+# ------------------------------- Index patterns -------------------------------
+#
+# Default index pattern to use.
+#pattern: wazuh-alerts-*
+#
+# ----------------------------------- Checks -----------------------------------
+#
+# Defines which checks must to be consider by the healthcheck
+# step once the Wazuh app starts. Values must to be true or false.
+#checks.pattern : true
+#checks.template: true
+#checks.api     : true
+#checks.setup   : true
+#checks.metaFields: true
+#
+# --------------------------------- Extensions ---------------------------------
+#
+# Defines which extensions should be activated when you add a new API entry.
+# You can change them after Wazuh app starts.
+# Values must to be true or false.
+#extensions.pci       : true
+#extensions.gdpr      : true
+#extensions.hipaa     : true
+#extensions.nist      : true
+#extensions.tsc       : true
+#extensions.audit     : true
+#extensions.oscap     : false
+#extensions.ciscat    : false
+#extensions.aws       : false
+#extensions.gcp       : false
+#extensions.virustotal: false
+#extensions.osquery   : false
+#extensions.docker    : false
+#
+# ---------------------------------- Time out ----------------------------------
+#
+# Defines maximum timeout to be used on the Wazuh app requests.
+# It will be ignored if it is bellow 1500.
+# It means milliseconds before we consider a request as failed.
+# Default: 20000
+#timeout: 20000
+#
+# -------------------------------- API selector --------------------------------
+#
+# Defines if the user is allowed to change the selected
+# API directly from the Wazuh app top menu.
+# Default: true
+#api.selector: true
+#
+# --------------------------- Index pattern selector ---------------------------
+#
+# Defines if the user is allowed to change the selected
+# index pattern directly from the Wazuh app top menu.
+# Default: true
+#ip.selector: true
+#
+# List of index patterns to be ignored
+#ip.ignore: []
+#
+# -------------------------------- X-Pack RBAC ---------------------------------
+#
+# Custom setting to enable/disable built-in X-Pack RBAC security capabilities.
+# Default: enabled
+#xpack.rbac.enabled: true
+#
+# ------------------------------ wazuh-monitoring ------------------------------
+#
+# Custom setting to enable/disable wazuh-monitoring indices.
+# Values: true, false, worker
+# If worker is given as value, the app will show the Agents status
+# visualization but won't insert data on wazuh-monitoring indices.
+# Default: true
+#wazuh.monitoring.enabled: true
+#
+# Custom setting to set the frequency for wazuh-monitoring indices cron task.
+# Default: 900 (s)
+#wazuh.monitoring.frequency: 900
+#
+# Configure wazuh-monitoring-* indices shards and replicas.
+#wazuh.monitoring.shards: 2
+#wazuh.monitoring.replicas: 0
+#
+# Configure wazuh-monitoring-* indices custom creation interval.
+# Values: h (hourly), d (daily), w (weekly), m (monthly)
+# Default: d
+#wazuh.monitoring.creation: d
+#
+# Default index pattern to use for Wazuh monitoring
+#wazuh.monitoring.pattern: wazuh-monitoring-*
+#
+# --------------------------------- wazuh-cron ----------------------------------
+#
+# Customize the index prefix of predefined jobs
+# This change is not retroactive, if you change it new indexes will be created
+# cron.prefix: test
+#
+# ------------------------------ wazuh-statistics -------------------------------
+#
+# Custom setting to enable/disable statistics tasks.
+#cron.statistics.status: true
+#
+# Enter the ID of the APIs you want to save data from, leave this empty to run
+# the task on all configured APIs
+#cron.statistics.apis: []
+#
+# Define the frequency of task execution using cron schedule expressions
+#cron.statistics.interval: 0 0 * * * *
+#
+# Define the name of the index in which the documents are to be saved.
+#cron.statistics.index.name: statistics
+#
+# Define the interval in which the index will be created
+#cron.statistics.index.creation: w
+#
+# ------------------------------- App privileges --------------------------------
+#admin: true
+#
+# ---------------------------- Hide manager alerts ------------------------------
+# Hide the alerts of the manager in all dashboards and discover
+#hideManagerAlerts: false
+#
+# ------------------------------- App logging level -----------------------------
+# Set the logging level for the Wazuh App log files.
+# Default value: info
+# Allowed values: info, debug
+#logs.level: info
+#
+# -------------------------------- Enrollment DNS -------------------------------
+# Set the variable WAZUH_REGISTRATION_SERVER in agents deployment.
+# Default value: ''
+#enrollment.dns: ''
+#
+#-------------------------------- API entries -----------------------------------
+#The following configuration is the default structure to define an API entry.
+#
+#hosts:
+#  - <id>:
+#     url: http(s)://<url>
+#     port: <port>
+#     username: <username>
+#     password: <password>
+

--- a/kibana/config/wazuh.yml
+++ b/kibana/config/wazuh.yml
@@ -1,7 +1,7 @@
 ---
 #
 # Wazuh app - App configuration file
-# Copyright (C) 2015-2020 Wazuh, Inc.
+# Copyright (C) 2015-2021 Wazuh, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/kibana/config/wazuh_app_config.sh
+++ b/kibana/config/wazuh_app_config.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+
+wazuh_url="${WAZUH_API_URL:-https://wazuh}"
+wazuh_port="${API_PORT:-55000}"
+api_username="${API_USERNAME:-wazuh-wui}"
+api_password="${API_PASSWORD:-wazuh-wui}"
+
+kibana_config_file="/usr/share/kibana/optimize/wazuh/config/wazuh.yml"
+
+declare -A CONFIG_MAP=(
+  [pattern]=$PATTERN
+  [checks.pattern]=$CHECKS_PATTERN
+  [checks.template]=$CHECKS_TEMPLATE
+  [checks.api]=$CHECKS_API
+  [checks.setup]=$CHECKS_SETUP
+  [extensions.pci]=$EXTENSIONS_PCI
+  [extensions.gdpr]=$EXTENSIONS_GDPR
+  [extensions.hipaa]=$EXTENSIONS_HIPAA
+  [extensions.nist]=$EXTENSIONS_NIST
+  [extensions.tsc]=$EXTENSIONS_TSC
+  [extensions.audit]=$EXTENSIONS_AUDIT
+  [extensions.oscap]=$EXTENSIONS_OSCAP
+  [extensions.ciscat]=$EXTENSIONS_CISCAT
+  [extensions.aws]=$EXTENSIONS_AWS
+  [extensions.gcp]=$EXTENSIONS_GCP
+  [extensions.virustotal]=$EXTENSIONS_VIRUSTOTAL
+  [extensions.osquery]=$EXTENSIONS_OSQUERY
+  [extensions.docker]=$EXTENSIONS_DOCKER
+  [timeout]=$APP_TIMEOUT
+  [api.selector]=$API_SELECTOR
+  [ip.selector]=$IP_SELECTOR
+  [ip.ignore]=$IP_IGNORE
+  [wazuh.monitoring.enabled]=$WAZUH_MONITORING_ENABLED
+  [wazuh.monitoring.frequency]=$WAZUH_MONITORING_FREQUENCY
+  [wazuh.monitoring.shards]=$WAZUH_MONITORING_SHARDS
+  [wazuh.monitoring.replicas]=$WAZUH_MONITORING_REPLICAS
+  [admin]=$ADMIN_PRIVILEGES
+)
+
+for i in "${!CONFIG_MAP[@]}"
+do
+    if [ "${CONFIG_MAP[$i]}" != "" ]; then
+        sed -i 's/.*#'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $kibana_config_file
+    fi
+done
+
+CONFIG_CODE=$(curl ${auth} -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/_doc/1513629884013)
+
+grep -q 1513629884013 $kibana_config_file
+_config_exists=$?
+
+if [[ "x$CONFIG_CODE" != "x200" && $_config_exists -ne 0 ]]; then
+cat << EOF >> $kibana_config_file
+hosts:
+  - 1513629884013:
+      url: $wazuh_url
+      port: $wazuh_port
+      username: $api_username
+      password: $api_password
+EOF
+else
+  echo "Wazuh APP already configured"
+fi

--- a/kibana/config/wazuh_app_config.sh
+++ b/kibana/config/wazuh_app_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+# Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 
 wazuh_url="${WAZUH_API_URL:-https://wazuh}"
 wazuh_port="${API_PORT:-55000}"

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+
+kibana_config_file="/usr/share/kibana/config/kibana.yml"
+if grep -Fq  "#xpack features" "$kibana_config_file";
+then
+  declare -A CONFIG_MAP=(
+    [xpack.apm.ui.enabled]=$XPACK_APM
+    [xpack.grokdebugger.enabled]=$XPACK_DEVTOOLS
+    [xpack.searchprofiler.enabled]=$XPACK_DEVTOOLS
+    [xpack.ml.enabled]=$XPACK_ML
+    [xpack.canvas.enabled]=$XPACK_CANVAS
+    [xpack.infra.enabled]=$XPACK_INFRA
+    [xpack.monitoring.enabled]=$XPACK_MONITORING
+    [console.enabled]=$XPACK_DEVTOOLS
+  )
+  for i in "${!CONFIG_MAP[@]}"
+  do
+    if [ "${CONFIG_MAP[$i]}" != "" ]; then
+      sed -i 's/.'"$i"'.*/'"$i"': '"${CONFIG_MAP[$i]}"'/' $kibana_config_file
+    fi
+  done
+else
+  echo "
+#xpack features
+xpack.apm.ui.enabled: $XPACK_APM
+xpack.grokdebugger.enabled: $XPACK_DEVTOOLS
+xpack.searchprofiler.enabled: $XPACK_DEVTOOLS
+xpack.ml.enabled: $XPACK_ML
+xpack.canvas.enabled: $XPACK_CANVAS
+xpack.infra.enabled: $XPACK_INFRA
+xpack.monitoring.enabled: $XPACK_MONITORING
+console.enabled: $XPACK_DEVTOOLS
+" >> $kibana_config_file
+fi

--- a/kibana/config/xpack_config.sh
+++ b/kibana/config/xpack_config.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Wazuh Docker Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+# Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 
 kibana_config_file="/usr/share/kibana/config/kibana.yml"
 if grep -Fq  "#xpack features" "$kibana_config_file";

--- a/wazuh-odfe/Dockerfile
+++ b/wazuh-odfe/Dockerfile
@@ -1,6 +1,7 @@
 # Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 FROM centos:7
 
+ARG FILEBEAT_CHANNEL=filebeat-oss
 ARG FILEBEAT_VERSION=7.9.1
 ARG WAZUH_VERSION=4.0.4-1
 ARG TEMPLATE_VERSION="master"
@@ -16,8 +17,8 @@ RUN yum --enablerepo=updates clean metadata && \
   sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo && \
   yum clean all && rm -rf /var/cache/yum
 
-RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-${FILEBEAT_VERSION}-x86_64.rpm &&\
-  rpm -i filebeat-oss-${FILEBEAT_VERSION}-x86_64.rpm && rm -f filebeat-oss-${FILEBEAT_VERSION}-x86_64.rpm
+RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm &&\
+  rpm -i ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm && rm -f ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm
 
 RUN curl -s https://packages.wazuh.com/4.x/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
 

--- a/xpack-compose.yml
+++ b/xpack-compose.yml
@@ -1,0 +1,85 @@
+# Wazuh App Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+version: '3.7'
+
+services:
+  wazuh:
+    build:
+      context: wazuh-odfe/
+      args:
+        - FILEBEAT_CHANNEL=filebeat
+        - FILEBEAT_VERSION=7.9.3
+    image: wazuh/wazuh:4.0.3_7.9.3_dev
+    hostname: wazuh-manager
+    restart: always
+    ports:
+      - "1514:1514"
+      - "1515:1515"
+      - "514:514/udp"
+      - "55000:55000"
+    environment:
+      - ELASTICSEARCH_URL=http://elasticsearch:9200
+      - ELASTIC_USERNAME=admin
+      - ELASTIC_PASSWORD=admin
+      - FILEBEAT_SSL_VERIFICATION_MODE=none
+    volumes:
+      - ossec_api_configuration:/var/ossec/api/configuration
+      - ossec_etc:/var/ossec/etc
+      - ossec_logs:/var/ossec/logs
+      - ossec_queue:/var/ossec/queue
+      - ossec_var_multigroups:/var/ossec/var/multigroups
+      - ossec_integrations:/var/ossec/integrations
+      - ossec_active_response:/var/ossec/active-response/bin
+      - ossec_agentless:/var/ossec/agentless
+      - ossec_wodles:/var/ossec/wodles
+      - filebeat_etc:/etc/filebeat
+      - filebeat_var:/var/lib/filebeat
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    hostname: elasticsearch
+    restart: always
+    ports:
+      - "9200:9200"
+    environment:
+      - discovery.type=single-node
+      - cluster.name=wazuh-cluster
+      - network.host=0.0.0.0
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - bootstrap.memory_lock=true
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+
+  kibana:
+    build: kibana/
+    image: wazuh/wazuh-kibana:4.0.3_7.9.3_dev
+    hostname: kibana
+    restart: always
+    ports:
+      - 5601:5601
+    environment:
+      - ELASTICSEARCH_USERNAME=admin
+      - ELASTICSEARCH_PASSWORD=admin
+      - ELASTICSEARCH_URL=http://elasticsearch:9200
+    depends_on:
+      - elasticsearch
+    links:
+      - elasticsearch:elasticsearch
+      - wazuh:wazuh
+
+volumes:
+  ossec_api_configuration:
+  ossec_etc:
+  ossec_logs:
+  ossec_queue:
+  ossec_var_multigroups:
+  ossec_integrations:
+  ossec_active_response:
+  ossec_agentless:
+  ossec_wodles:
+  filebeat_etc:
+  filebeat_var:

--- a/xpack-compose.yml
+++ b/xpack-compose.yml
@@ -1,4 +1,4 @@
-# Wazuh App Copyright (C) 2020 Wazuh Inc. (License GPLv2)
+# Wazuh App Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 version: '3.7'
 
 services:
@@ -8,7 +8,7 @@ services:
       args:
         - FILEBEAT_CHANNEL=filebeat
         - FILEBEAT_VERSION=7.9.3
-    image: wazuh/wazuh:4.0.3_7.9.3_dev
+    image: wazuh/wazuh:4.0.4_7.9.3_dev
     hostname: wazuh-manager
     restart: always
     ports:
@@ -56,7 +56,7 @@ services:
 
   kibana:
     build: kibana/
-    image: wazuh/wazuh-kibana:4.0.3_7.9.3_dev
+    image: wazuh/wazuh-kibana:4.0.4_7.9.3_dev
     hostname: kibana
     restart: always
     ports:

--- a/xpack-compose.yml
+++ b/xpack-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         - FILEBEAT_CHANNEL=filebeat
         - FILEBEAT_VERSION=7.9.3
-    image: wazuh/wazuh:4.0.4_7.9.3_dev
+    image: wazuh/wazuh:4.0.4_7.9.3
     hostname: wazuh-manager
     restart: always
     ports:
@@ -152,7 +152,7 @@ services:
 
   kibana:
     build: kibana/
-    image: wazuh/wazuh-kibana:4.0.4_7.9.3_dev
+    image: wazuh/wazuh-kibana:4.0.4_7.9.3
     hostname: kibana
     restart: always
     ports:

--- a/xpack-compose.yml
+++ b/xpack-compose.yml
@@ -17,10 +17,13 @@ services:
       - "514:514/udp"
       - "55000:55000"
     environment:
-      - ELASTICSEARCH_URL=http://elasticsearch:9200
-      - ELASTIC_USERNAME=admin
-      - ELASTIC_PASSWORD=admin
+      - ELASTICSEARCH_URL=https://elasticsearch:9200
+      - ELASTIC_USERNAME=elastic
+      - ELASTIC_PASSWORD=SecretPassword
       - FILEBEAT_SSL_VERIFICATION_MODE=none
+      - SSL_CERTIFICATE_AUTHORITIES=/etc/ssl/ca.crt
+      - SSL_CERTIFICATE=/etc/ssl/wazuh.crt
+      - SSL_KEY=/etc/ssl/wazuh.key
     volumes:
       - ossec_api_configuration:/var/ossec/api/configuration
       - ossec_etc:/var/ossec/etc
@@ -33,6 +36,10 @@ services:
       - ossec_wodles:/var/ossec/wodles
       - filebeat_etc:/etc/filebeat
       - filebeat_var:/var/lib/filebeat
+      - ./xpack/ca/ca.crt:/etc/ssl/ca.crt
+      - ./xpack/wazuh/wazuh.crt:/etc/ssl/wazuh.crt
+      - ./xpack/wazuh/wazuh.key:/etc/ssl/wazuh.key
+
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
@@ -41,11 +48,24 @@ services:
     ports:
       - "9200:9200"
     environment:
-      - discovery.type=single-node
       - cluster.name=wazuh-cluster
-      - network.host=0.0.0.0
+      - node.name=elasticsearch
+      - discovery.seed_hosts=elasticsearch,elasticsearch2,elasticsearch3
+      - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
+      - ELASTIC_PASSWORD=SecretPassword
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - bootstrap.memory_lock=true
+      - xpack.license.self_generated.type=basic
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.certificate_authorities=/usr/share/elasticsearch/config/ca.crt
+      - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/elasticsearch.key
+      - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/elasticsearch.crt
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.certificate_authorities=/usr/share/elasticsearch/config/ca.crt
+      - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/elasticsearch.key
+      - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/elasticsearch.crt
     ulimits:
       memlock:
         soft: -1
@@ -53,6 +73,82 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    volumes:
+      - ./xpack/ca/ca.crt:/usr/share/elasticsearch/config/ca.crt
+      - ./xpack/elasticsearch/elasticsearch.key:/usr/share/elasticsearch/config/elasticsearch.key
+      - ./xpack/elasticsearch/elasticsearch.crt:/usr/share/elasticsearch/config/elasticsearch.crt
+
+  elasticsearch2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    hostname: elasticsearch2
+    restart: always
+    environment:
+      - cluster.name=wazuh-cluster
+      - node.name=elasticsearch2
+      - discovery.seed_hosts=elasticsearch,elasticsearch2,elasticsearch3
+      - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
+      - ELASTIC_PASSWORD=SecretPassword
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - bootstrap.memory_lock=true
+      - xpack.license.self_generated.type=basic
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.certificate_authorities=/usr/share/elasticsearch/config/ca.crt
+      - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/elasticsearch.key
+      - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/elasticsearch.crt
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.certificate_authorities=/usr/share/elasticsearch/config/ca.crt
+      - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/elasticsearch.key
+      - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/elasticsearch.crt
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - ./xpack/ca/ca.crt:/usr/share/elasticsearch/config/ca.crt
+      - ./xpack/elasticsearch2/elasticsearch2.key:/usr/share/elasticsearch/config/elasticsearch.key
+      - ./xpack/elasticsearch2/elasticsearch2.crt:/usr/share/elasticsearch/config/elasticsearch.crt
+
+  elasticsearch3:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    hostname: elasticsearch3
+    restart: always
+    environment:
+      - cluster.name=wazuh-cluster
+      - node.name=elasticsearch3
+      - discovery.seed_hosts=elasticsearch,elasticsearch2,elasticsearch3
+      - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
+      - ELASTIC_PASSWORD=SecretPassword
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - bootstrap.memory_lock=true
+      - xpack.license.self_generated.type=basic
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.certificate_authorities=/usr/share/elasticsearch/config/ca.crt
+      - xpack.security.http.ssl.key=/usr/share/elasticsearch/config/elasticsearch.key
+      - xpack.security.http.ssl.certificate=/usr/share/elasticsearch/config/elasticsearch.crt
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.security.transport.ssl.certificate_authorities=/usr/share/elasticsearch/config/ca.crt
+      - xpack.security.transport.ssl.key=/usr/share/elasticsearch/config/elasticsearch.key
+      - xpack.security.transport.ssl.certificate=/usr/share/elasticsearch/config/elasticsearch.crt
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - ./xpack/ca/ca.crt:/usr/share/elasticsearch/config/ca.crt
+      - ./xpack/elasticsearch3/elasticsearch3.key:/usr/share/elasticsearch/config/elasticsearch.key
+      - ./xpack/elasticsearch3/elasticsearch3.crt:/usr/share/elasticsearch/config/elasticsearch.crt
+
+
 
   kibana:
     build: kibana/
@@ -60,11 +156,22 @@ services:
     hostname: kibana
     restart: always
     ports:
-      - 5601:5601
+      - 443:5601
     environment:
-      - ELASTICSEARCH_USERNAME=admin
-      - ELASTICSEARCH_PASSWORD=admin
-      - ELASTICSEARCH_URL=http://elasticsearch:9200
+      - SERVERNAME=localhost
+      - ELASTICSEARCH_USERNAME=elastic
+      - ELASTICSEARCH_PASSWORD=SecretPassword
+      - ELASTICSEARCH_URL=https://elasticsearch:9200
+      - ELASTICSEARCH_HOSTS=https://elasticsearch:9200
+      - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=/usr/share/kibana/config/ca.crt
+      - SERVER_SSL_ENABLED=true
+      - XPACK_SECURITY_ENABLED=true
+      - SERVER_SSL_KEY=/usr/share/kibana/config/kibana.key
+      - SERVER_SSL_CERTIFICATE=/usr/share/kibana/config/kibana.crt
+    volumes:
+      - ./xpack/ca/ca.crt:/usr/share/kibana/config/ca.crt
+      - ./xpack/kibana/kibana.key:/usr/share/kibana/config/kibana.key
+      - ./xpack/kibana/kibana.crt:/usr/share/kibana/config/kibana.crt
     depends_on:
       - elasticsearch
     links:

--- a/xpack/instances.yml
+++ b/xpack/instances.yml
@@ -1,0 +1,35 @@
+instances:
+  - name: elasticsearch
+    dns:
+      - elasticsearch
+      - localhost
+    ip:
+      - 127.0.0.1
+
+  - name: elasticsearch2
+    dns:
+      - elasticsearch2
+      - localhost
+    ip:
+      - 127.0.0.1
+
+  - name: elasticsearch3
+    dns:
+      - elasticsearch3
+      - localhost
+    ip:
+      - 127.0.0.1
+
+  - name: kibana
+    dns:
+      - kibana
+      - localhost
+    ip:
+      - 127.0.0.1
+
+  - name: wazuh
+    dns:
+      - wazuh
+      - localhost
+    ip:
+      - 127.0.0.1


### PR DESCRIPTION
This PR closes #398 

### Changes

- Backport kibana-xpack image
- Add the ARG `FILEBEAT_CHANNEL` on the wazuh-odfe Dockefile to allow for both regular filebeat and oss versions.
- Add `xpack-compose.yml` with sample deployment
- Add `generate-elasticsearch-certs.yml` and `xpack/instances.yml` for SSL cert generation


