### PR TITLE
Adopt Wazuh standard on tool names

### DIFF
--- a/production_cluster/wazuh_cluster/wazuh_manager.conf
+++ b/production_cluster/wazuh_cluster/wazuh_manager.conf
@@ -94,7 +94,7 @@
     <ignore_time>6h</ignore_time>
     <run_on_start>yes</run_on_start>
 
-    <!-- Ubuntu OS vulnerabilities --> 
+    <!-- Ubuntu OS vulnerabilities -->
     <provider name="canonical">
       <enabled>no</enabled>
       <os>trusty</os>
@@ -104,7 +104,7 @@
       <update_interval>1h</update_interval>
     </provider>
 
-    <!-- Debian OS vulnerabilities -->  
+    <!-- Debian OS vulnerabilities -->
     <provider name="debian">
       <enabled>no</enabled>
       <os>stretch</os>
@@ -112,7 +112,7 @@
       <update_interval>1h</update_interval>
     </provider>
 
-    <!-- RedHat OS vulnerabilities -->  
+    <!-- RedHat OS vulnerabilities -->
     <provider name="redhat">
       <enabled>no</enabled>
       <os>5</os>
@@ -307,7 +307,7 @@
     <rule_dir>etc/rules</rule_dir>
   </ruleset>
 
-  <!-- Configuration for ossec-authd -->
+  <!-- Configuration for wazuh-authd -->
   <auth>
     <disabled>no</disabled>
     <port>1515</port>
@@ -346,4 +346,4 @@
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
-</ossec_config> 
+</ossec_config>

--- a/production_cluster/wazuh_cluster/wazuh_worker.conf
+++ b/production_cluster/wazuh_cluster/wazuh_worker.conf
@@ -94,7 +94,7 @@
     <ignore_time>6h</ignore_time>
     <run_on_start>yes</run_on_start>
 
-    <!-- Ubuntu OS vulnerabilities --> 
+    <!-- Ubuntu OS vulnerabilities -->
     <provider name="canonical">
       <enabled>no</enabled>
       <os>trusty</os>
@@ -104,7 +104,7 @@
       <update_interval>1h</update_interval>
     </provider>
 
-    <!-- Debian OS vulnerabilities -->  
+    <!-- Debian OS vulnerabilities -->
     <provider name="debian">
       <enabled>no</enabled>
       <os>stretch</os>
@@ -112,7 +112,7 @@
       <update_interval>1h</update_interval>
     </provider>
 
-    <!-- RedHat OS vulnerabilities -->  
+    <!-- RedHat OS vulnerabilities -->
     <provider name="redhat">
       <enabled>no</enabled>
       <os>5</os>
@@ -307,7 +307,7 @@
     <rule_dir>etc/rules</rule_dir>
   </ruleset>
 
-  <!-- Configuration for ossec-authd -->
+  <!-- Configuration for wazuh-authd -->
   <auth>
     <disabled>no</disabled>
     <port>1515</port>
@@ -346,4 +346,4 @@
     <log_format>syslog</log_format>
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
-</ossec_config> 
+</ossec_config>

--- a/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
+++ b/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
@@ -94,7 +94,7 @@ remove_data_files() {
 ##############################################################################
 
 create_ossec_key_cert() {
-  print "Creating ossec-authd key and cert"
+  print "Creating wazuh-authd key and cert"
   exec_cmd "openssl genrsa -out ${WAZUH_INSTALL_PATH}/etc/sslmanager.key 4096"
   exec_cmd "openssl req -new -x509 -key ${WAZUH_INSTALL_PATH}/etc/sslmanager.key -out ${WAZUH_INSTALL_PATH}/etc/sslmanager.cert -days 3650 -subj /CN=${HOSTNAME}/"
 }
@@ -161,7 +161,7 @@ main() {
   # Remove some files in permanent_data (i.e. .template.db)
   remove_data_files
 
-  # Generate ossec-authd certs if AUTO_ENROLLMENT_ENABLED is true and does not exist
+  # Generate wazuh-authd certs if AUTO_ENROLLMENT_ENABLED is true and does not exist
   if [ $AUTO_ENROLLMENT_ENABLED == true ]
   then
     if [ ! -e ${WAZUH_INSTALL_PATH}/etc/sslmanager.key ]

--- a/wazuh-odfe/config/etc/cont-init.d/2-manager
+++ b/wazuh-odfe/config/etc/cont-init.d/2-manager
@@ -110,4 +110,4 @@ function_wazuh_migration
 function_create_custom_user
 
 # Start Wazuh
-/var/ossec/bin/ossec-control start
+/var/ossec/bin/wazuh-control start


### PR DESCRIPTION
This PR closes #418  and #421


## Changes

- Update references to deprecated `ossec-` prefix in favor of `wazuh-` prefix