### PR TITLE
Update generate-self-signed-cert.sh

### DIFF
--- a/production_cluster/kibana_ssl/generate-self-signed-cert.sh
+++ b/production_cluster/kibana_ssl/generate-self-signed-cert.sh
@@ -9,4 +9,6 @@ then
     exit
 else
     openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -keyout key.pem -out cert.pem
+    chmod 0666 key.pem
+    chmod 0666 cert.pem
 fi


### PR DESCRIPTION
Modify permissions of self-generated certs to allow Kibana docker instance the ability to read the file on start.