### PR TITLE
Add goss binary for health checks

### DIFF
--- a/wazuh-odfe/Dockerfile
+++ b/wazuh-odfe/Dockerfile
@@ -22,6 +22,8 @@ RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_
 
 RUN curl -s https://packages.wazuh.com/4.x/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
 
+RUN curl -L https://github.com/aelsabbahy/goss/releases/latest/download/goss-linux-amd64 -o /usr/local/bin/goss && chmod +rx /usr/local/bin/goss
+
 ARG S6_VERSION="v2.2.0.1"
 RUN curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz \
     -o /tmp/s6-overlay-amd64.tar.gz && \


### PR DESCRIPTION
This PR fixes #438 

## Changes

- Add the `goss` binary for health checks on both Docker and Kubernetes