### PR TITLE
Rename users and group according to Wazuh standard

### DIFF
--- a/.goss.yaml
+++ b/.goss.yaml
@@ -16,22 +16,22 @@ file:
   /var/ossec/etc/lists/audit-keys:
     exists: true
     mode: "0660"
-    owner: ossec
-    group: ossec
+    owner: wazuh
+    group: wazuh
     filetype: file
     contains: []
   /var/ossec/etc/ossec.conf:
     exists: true
     mode: "0660"
     owner: root
-    group: ossec
+    group: wazuh
     filetype: file
     contains: []
   /var/ossec/etc/rules/local_rules.xml:
     exists: true
     mode: "0660"
-    owner: ossec
-    group: ossec
+    owner: wazuh
+    group: wazuh
     filetype: file
     contains: []
   /var/ossec/etc/sslmanager.cert:
@@ -71,26 +71,26 @@ port:
     ip:
     - 0.0.0.0
 user:
-  ossec:
+  wazuh:
     exists: true
     groups:
-    - ossec
+    - wazuh
     home: /var/ossec
     shell: /sbin/nologin
-  ossecm:
+  wazuh:
     exists: true
     groups:
-    - ossec
+    - wazuh
     home: /var/ossec
     shell: /sbin/nologin
-  ossecr:
+  wazuh:
     exists: true
     groups:
-    - ossec
+    - wazuh
     home: /var/ossec
     shell: /sbin/nologin
 group:
-  ossec:
+  wazuh:
     exists: true
 process:
   filebeat:

--- a/production_cluster/wazuh_cluster/wazuh_manager.conf
+++ b/production_cluster/wazuh_cluster/wazuh_manager.conf
@@ -6,7 +6,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/production_cluster/wazuh_cluster/wazuh_worker.conf
+++ b/production_cluster/wazuh_cluster/wazuh_worker.conf
@@ -6,7 +6,7 @@
     <logall_json>no</logall_json>
     <email_notification>no</email_notification>
     <smtp_server>smtp.example.wazuh.com</smtp_server>
-    <email_from>ossecm@example.wazuh.com</email_from>
+    <email_from>wazuh@example.wazuh.com</email_from>
     <email_to>recipient@example.wazuh.com</email_to>
     <email_maxperhour>12</email_maxperhour>
     <email_log_source>alerts.log</email_log_source>

--- a/wazuh-odfe/Dockerfile
+++ b/wazuh-odfe/Dockerfile
@@ -39,7 +39,7 @@ ADD https://raw.githubusercontent.com/wazuh/wazuh/$TEMPLATE_VERSION/extensions/e
 RUN chmod go-w /etc/filebeat/wazuh-template.json
 
 COPY config/etc/ /etc/
-COPY --chown=root:ossec config/create_user.py /var/ossec/framework/scripts/create_user.py
+COPY --chown=root:wazuh config/create_user.py /var/ossec/framework/scripts/create_user.py
 
 # Prepare permanent data
 # Sync calls are due to https://github.com/docker/docker/issues/9547

--- a/wazuh-odfe/config/etc/cont-init.d/2-manager
+++ b/wazuh-odfe/config/etc/cont-init.d/2-manager
@@ -36,11 +36,11 @@ function_wazuh_migration(){
       fi
 
       \cp -f /wazuh-migration/data/etc/ossec.conf /var/ossec/etc/ossec.conf
-      chown root:ossec /var/ossec/etc/ossec.conf
+      chown root:wazuh /var/ossec/etc/ossec.conf
       chmod 640 /var/ossec/etc/ossec.conf
 
       \cp -f /wazuh-migration/data/etc/client.keys /var/ossec/etc/client.keys
-      chown ossec:ossec /var/ossec/etc/client.keys
+      chown wazuh:wazuh /var/ossec/etc/client.keys
       chmod 640 /var/ossec/etc/client.keys
 
       \cp -f /wazuh-migration/data/etc/sslmanager.cert /var/ossec/etc/sslmanager.cert
@@ -49,25 +49,25 @@ function_wazuh_migration(){
       chmod 640 /var/ossec/etc/sslmanager.cert /var/ossec/etc/sslmanager.key
 
       \cp -f /wazuh-migration/data/etc/shared/default/agent.conf /var/ossec/etc/shared/default/agent.conf
-      chown ossec:ossec /var/ossec/etc/shared/default/agent.conf
+      chown wazuh:wazuh /var/ossec/etc/shared/default/agent.conf
       chmod 660 /var/ossec/etc/shared/default/agent.conf
 
       \cp -f /wazuh-migration/data/etc/decoders/* /var/ossec/etc/decoders/
-      chown ossec:ossec /var/ossec/etc/decoders/*
+      chown wazuh:wazuh /var/ossec/etc/decoders/*
       chmod 660 /var/ossec/etc/decoders/*
 
       \cp -f /wazuh-migration/data/etc/rules/* /var/ossec/etc/rules/
-      chown ossec:ossec /var/ossec/etc/rules/*
+      chown wazuh:wazuh /var/ossec/etc/rules/*
       chmod 660 /var/ossec/etc/rules/*
 
       if [ -e /wazuh-migration/data/agentless/.passlist ]; then
         \cp -f /wazuh-migration/data/agentless/.passlist /var/ossec/agentless/.passlist
-        chown root:ossec /var/ossec/agentless/.passlist
+        chown root:wazuh /var/ossec/agentless/.passlist
         chmod 640 /var/ossec/agentless/.passlist
       fi
 
       \cp -f /wazuh-migration/global.db /var/ossec/queue/db/global.db
-      chown ossec:ossec /var/ossec/queue/db/global.db
+      chown wazuh:wazuh /var/ossec/queue/db/global.db
       chmod 640 /var/ossec/queue/db/global.db
 
       # mark volume as migrated


### PR DESCRIPTION
Hi team,
This PR closes #448, changes `ossec`, `ossecr` and `ossecm` users and groups to `wazuh`.

Greetings,
Víctor.