### PR TITLE
457: Broken link fix and removed deprecated information at README  to 5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ In addition, a docker-compose file is provided to launch the containers mentione
 * [Docker hub](https://hub.docker.com/u/wazuh)
 
 
-### Setup SSL certificate and Basic Authentication
+### Setup SSL certificate
 
-Before starting the environment it is required to provide an SSL certificate (or just generate one self-signed) and setup the basic auth.
+Before starting the environment it is required to provide an SSL certificate (or just generate one self-signed).
 
-Documentation on how to provide these two can be found at [nginx_conf/README.md](nginx_conf/README.md).
+Documentation on how to provide these two can be found at [Wazuh Docer Documentation](https://documentation.wazuh.com/current/docker/wazuh-container.html#production-deployment).
 
 
 ## Environment Variables


### PR DESCRIPTION
Closes #457

This PR corrects a broken link at `README.md` and removes unused information about basic auth.