### PR TITLE
Add admin keypair to production deployment

### DIFF
--- a/production-cluster.yml
+++ b/production-cluster.yml
@@ -86,6 +86,8 @@ services:
       - ./production_cluster/ssl_certs/root-ca.pem:/usr/share/elasticsearch/config/root-ca.pem
       - ./production_cluster/ssl_certs/node1.key:/usr/share/elasticsearch/config/node1.key
       - ./production_cluster/ssl_certs/node1.pem:/usr/share/elasticsearch/config/node1.pem
+      - ./production_cluster/ssl_certs/admin.pem:/usr/share/elasticsearch/config/admin.pem
+      - ./production_cluster/ssl_certs/admin.key:/usr/share/elasticsearch/config/admin.key      
       - ./production_cluster/elastic_opendistro/elasticsearch-node1.yml:/usr/share/elasticsearch/config/elasticsearch.yml
       - ./production_cluster/elastic_opendistro/internal_users.yml:/usr/share/elasticsearch/plugins/opendistro_security/securityconfig/internal_users.yml
 

--- a/production_cluster/elastic_opendistro/elasticsearch-node1.yml
+++ b/production_cluster/elastic_opendistro/elasticsearch-node1.yml
@@ -20,7 +20,7 @@ opendistro_security.nodes_dn:
     - 'CN=node2,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
     - 'CN=node3,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
     - 'CN=filebeat,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
-opendistro_security.authcz.admin_dn: []
+opendistro_security.authcz.admin_dn: ['CN=admin,OU=Ops,O=Example\, Inc.,DC=example,DC=com']
 opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true

--- a/production_cluster/elastic_opendistro/elasticsearch-node2.yml
+++ b/production_cluster/elastic_opendistro/elasticsearch-node2.yml
@@ -20,7 +20,7 @@ opendistro_security.nodes_dn:
     - 'CN=node2,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
     - 'CN=node3,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
     - 'CN=filebeat,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
-opendistro_security.authcz.admin_dn: []
+opendistro_security.authcz.admin_dn: ['CN=admin,OU=Ops,O=Example\, Inc.,DC=example,DC=com']
 opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true

--- a/production_cluster/elastic_opendistro/elasticsearch-node3.yml
+++ b/production_cluster/elastic_opendistro/elasticsearch-node3.yml
@@ -20,7 +20,7 @@ opendistro_security.nodes_dn:
     - 'CN=node2,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
     - 'CN=node3,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
     - 'CN=filebeat,OU=Ops,O=Example\, Inc.,DC=example,DC=com'
-opendistro_security.authcz.admin_dn: []
+opendistro_security.authcz.admin_dn: ['CN=admin,OU=Ops,O=Example\, Inc.,DC=example,DC=com']
 opendistro_security.audit.type: internal_elasticsearch
 opendistro_security.enable_snapshot_restore_privilege: true
 opendistro_security.check_snapshot_restore_write_privileges: true

--- a/production_cluster/ssl_certs/certs.yml
+++ b/production_cluster/ssl_certs/certs.yml
@@ -28,3 +28,8 @@ nodes:
     dn: CN=filebeat,OU=Ops,O=Example\, Inc.,DC=example,DC=com
     dns: 
       - wazuh 
+      
+clients:
+  - name: admin
+    dn: CN=admin,OU=Ops,O=Example\, Inc.,DC=example,DC=com
+    admin: true


### PR DESCRIPTION
Hi team,

I've made some modifications to the configuration files in order to have an admin keypair to be able to change the Security index of the ODFE plugin.

Now, when generating the certificates with `docker-compose -f generate-opendistro-certs.yml run --rm generator` it will generate an `admin.key` and ` admin.pem` that can be used with the `securityadmin.sh` script to update the security index.

Regards.