### PR TITLE
Changes for CronTab and Ruleset from S3

### DIFF
--- a/wazuh-odfe/Dockerfile
+++ b/wazuh-odfe/Dockerfile
@@ -3,7 +3,7 @@ FROM centos:7
 
 ARG FILEBEAT_CHANNEL=filebeat-oss
 ARG FILEBEAT_VERSION=7.10.2
-ARG WAZUH_VERSION=4.3.0-1
+ARG WAZUH_VERSION=4.1.3
 ARG TEMPLATE_VERSION="master"
 ARG WAZUH_FILEBEAT_MODULE="wazuh-filebeat-0.1.tar.gz"
 
@@ -12,10 +12,15 @@ RUN rpm --import https://packages.wazuh.com/key/GPG-KEY-WAZUH
 
 COPY config/wazuh.repo /etc/yum.repos.d/wazuh.repo
 
+
+
 RUN yum --enablerepo=updates clean metadata && \
-  yum -y install openssl which expect openssh-clients && yum -y install wazuh-manager-${WAZUH_VERSION} -y && \
+  yum -y install openssl which expect openssh-clients crontabs unzip && yum -y install wazuh-manager-${WAZUH_VERSION} -y && \
   sed -i "s/^enabled=1/enabled=0/" /etc/yum.repos.d/wazuh.repo && \
   yum clean all && rm -rf /var/cache/yum
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+  unzip awscliv2.zip && ./aws/install && rm -rf aws
 
 RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm &&\
   rpm -i ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm && rm -f ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm

--- a/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
+++ b/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
@@ -147,11 +147,38 @@ set_custom_cluster_key() {
   sed -i 's/<key>to_be_replaced_by_cluster_key<\/key>/<key>'"${WAZUH_CLUSTER_KEY}"'<\/key>/g' ${WAZUH_INSTALL_PATH}/etc/ossec.conf
 }
 
+
+function_custom_aws_ruleset () {
+  if [[ ! -z "${WAZUH_RULESET_AWS_PATH}" ]];
+  then
+    echo "WAZUH_RULESET_AWS_PATH is set, Getting configs from ${WAZUH_RULESET_AWS_PATH}"
+    exec_cmd_stdout /usr/bin/aws s3 cp --recursive --include "*.xml" ${WAZUH_RULESET_AWS_PATH} /wazuh-migration/data/etc/rules/ || echo "Error occured while getting configs" && exit 1;
+ else
+   echo "WAZUH_RULESET_AWS_PATH is not given, Skipping Update Custom Configs!"
+  fi
+}
+
+
+function_install_cron_jobs() {
+  if [[ ! -z "${WAZUH_ENABLE_CRON}" ]];
+  then
+    echo "Installing Cron to delete logs older than a day"
+    exec_cmd_stdout crontab /app/custom-crons
+    exec_cmd_stdout chown 644 /etc/cron.d/*
+}
+
 ##############################################################################
 # Main function
 ##############################################################################
 
 main() {
+
+  # Mount Custom Rule set from AWS S3!
+  function_crontab_alert_ruleset
+
+  # Mount CronTab
+  function_install_cron_jobs
+
   # Mount permanent data  (i.e. ossec.conf)
   mount_permanent_data
 

--- a/wazuh-odfe/config/etc/cont-init.d/2-manager
+++ b/wazuh-odfe/config/etc/cont-init.d/2-manager
@@ -124,3 +124,6 @@ function_entrypoint_scripts
 
 # Start Wazuh
 /var/ossec/bin/wazuh-control start
+
+# Start CronTab
+/usr/sbin/crond

--- a/wazuh-odfe/config/permanent_data.env
+++ b/wazuh-odfe/config/permanent_data.env
@@ -15,6 +15,8 @@ export PERMANENT_DATA
 
 # Files mounted in a volume that should not be permanent
 i=0
+# Added ossec.conf to overwrite config from ConfigMap on every boot
+PERMANENT_DATA_EXCP[((i++))]="/var/ossec/etc/ossec.conf"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/etc/internal_options.conf"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/integrations/pagerduty"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/integrations/slack"


### PR DESCRIPTION
- Updated Version to 4.1.3
- Installed Crontab and `WAZUH_ENABLE_CRON` ENVto eventually delete files, Since Wazuh does not have an option to auto-delete.
- Added `WAZUH_RULESET_AWS_PATH` to fetch custom configs from s3 on initialisation 
- Moved `ossec.conf` to always update from User File on every initialisation (To pickup new changes from ossec.conf, It stores under permanent config by default)