### PR TITLE
in bash if already tests exit status is 0 or not

### DIFF
--- a/kibana-odfe/config/wazuh_app_config.sh
+++ b/kibana-odfe/config/wazuh_app_config.sh
@@ -47,10 +47,7 @@ done
 
 CONFIG_CODE=$(curl ${auth} -s -o /dev/null -w "%{http_code}" -XGET $el_url/.wazuh/_doc/1513629884013)
 
-grep -q 1513629884013 $kibana_config_file
-_config_exists=$?
-
-if [[ "x$CONFIG_CODE" != "x200" && $_config_exists -ne 0 ]]; then
+if [[ "x$CONFIG_CODE" != "x200" ]] && ! grep -q 1513629884013 $kibana_config_file ; then
 cat << EOF >> $kibana_config_file
 hosts:
   - 1513629884013:


### PR DESCRIPTION
The other way works too, but it seems pointless to go through extra steps when the if command already does exactly this