### PR TITLE
Fix 4.2 upgrade

### DIFF
--- a/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
+++ b/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
@@ -84,7 +84,7 @@ remove_data_files() {
     if [ -e ${del_file} ]
     then
       print "Removing ${del_file}"
-      exec_cmd "rm ${del_file}"
+      exec_cmd "rm -rf ${del_file}"
     fi
   done
 }

--- a/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
+++ b/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
@@ -101,7 +101,7 @@ remove_data_files() {
     if [ -e ${del_file} ]
     then
       print "Removing ${del_file}"
-      exec_cmd "rm -rf ${del_file}"
+      exec_cmd "rm -f ${del_file}"
     fi
   done
 }

--- a/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
+++ b/wazuh-odfe/config/etc/cont-init.d/0-wazuh-init
@@ -75,6 +75,23 @@ apply_exclusion_data() {
 }
 
 ##############################################################################
+# This function will rename in the permanent data volume every file
+# contained in PERMANENT_DATA_MOVE
+##############################################################################
+
+move_data_files() {
+  for mov_file in "${PERMANENT_DATA_MOVE[@]}"; do
+    file_split=( $mov_file )
+    if [ -e ${file_split[0]} ]
+    then
+      print "moving ${mov_file}"
+      exec_cmd "mv -f ${mov_file}"
+    fi
+  done
+}
+
+
+##############################################################################
 # This function will delete from the permanent data volume every file
 # contained in PERMANENT_DATA_DEL
 ##############################################################################
@@ -157,6 +174,9 @@ main() {
 
   # Restore files stored in permanent data that are not permanent  (i.e. internal_options.conf)
   apply_exclusion_data
+
+  # Rename files stored in permanent data (i.e. queue/ossec)
+  move_data_files
 
   # Remove some files in permanent_data (i.e. .template.db)
   remove_data_files

--- a/wazuh-odfe/config/permanent_data.env
+++ b/wazuh-odfe/config/permanent_data.env
@@ -4,6 +4,8 @@ PERMANENT_DATA[((i++))]="/var/ossec/api/configuration"
 PERMANENT_DATA[((i++))]="/var/ossec/etc"
 PERMANENT_DATA[((i++))]="/var/ossec/logs"
 PERMANENT_DATA[((i++))]="/var/ossec/queue"
+PERMANENT_DATA[((i++))]="/var/ossec/queue/sockets"
+PERMANENT_DATA[((i++))]="/var/ossec/queue/logcollector"
 PERMANENT_DATA[((i++))]="/var/ossec/agentless"
 PERMANENT_DATA[((i++))]="/var/ossec/var/multigroups"
 PERMANENT_DATA[((i++))]="/var/ossec/integrations"
@@ -62,4 +64,5 @@ export PERMANENT_DATA_EXCP
 # Files mounted in a volume that should be deleted
 i=0
 PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/db/.template.db"
+PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/ossec"
 export PERMANENT_DATA_DEL

--- a/wazuh-odfe/config/permanent_data.env
+++ b/wazuh-odfe/config/permanent_data.env
@@ -4,7 +4,6 @@ PERMANENT_DATA[((i++))]="/var/ossec/api/configuration"
 PERMANENT_DATA[((i++))]="/var/ossec/etc"
 PERMANENT_DATA[((i++))]="/var/ossec/logs"
 PERMANENT_DATA[((i++))]="/var/ossec/queue"
-PERMANENT_DATA[((i++))]="/var/ossec/queue/sockets"
 PERMANENT_DATA[((i++))]="/var/ossec/queue/logcollector"
 PERMANENT_DATA[((i++))]="/var/ossec/agentless"
 PERMANENT_DATA[((i++))]="/var/ossec/var/multigroups"
@@ -64,5 +63,9 @@ export PERMANENT_DATA_EXCP
 # Files mounted in a volume that should be deleted
 i=0
 PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/db/.template.db"
-PERMANENT_DATA_DEL[((i++))]="/var/ossec/queue/ossec"
 export PERMANENT_DATA_DEL
+
+i=0
+PERMANENT_DATA_MOVE[((i++))]="/var/ossec/logs/ossec /var/ossec/logs/wazuh"
+PERMANENT_DATA_MOVE[((i++))]="/var/ossec/queue/ossec /var/ossec/queue/sockets"
+export PERMANENT_DATA_MOVE


### PR DESCRIPTION
Closes #505 

This PR fixes a problem when upgrading wazuh-docker to 4.2.0 where the persistent volume in `/var/ossec/queue` caused  the manager to be unable to start.