### PR TITLE
Change tail argument to prevent log rotation issues

### DIFF
--- a/wazuh-odfe/config/etc/services.d/ossec-logs/run
+++ b/wazuh-odfe/config/etc/services.d/ossec-logs/run
@@ -1,4 +1,4 @@
 #!/usr/bin/with-contenv sh
 
 # dumping ossec.log to standard output
-exec tail -f /var/ossec/logs/ossec.log
+exec tail -F /var/ossec/logs/ossec.log


### PR DESCRIPTION
Hello team,

This PR aims to fix an issue where the container stops showing logs after the `ossec.log` file gets rotated.

I have replaced the `tail -f` command with `tail -F` to prevent that:

```shell
       -f, --follow[={name|descriptor}]
              output appended data as the file grows;

              an absent option argument means 'descriptor'

       -F     same as --follow=name --retry
```

Regards,
Franco Hielpos