### PR TITLE
Add environment variable to customize wazuh.monitoring.creation interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ IP_SELECTOR=true                # Defines if the user is allowed to change the s
 IP_IGNORE="[]"                  # List of index patterns to be ignored
 
 WAZUH_MONITORING_ENABLED=true       # Custom settings to enable/disable wazuh-monitoring indices
+WAZUH_MONITORING_CREATION=d         # Custom setting to set the wazuh-monitoring-* indices creation interval
 WAZUH_MONITORING_FREQUENCY=900      # Custom setting to set the frequency for wazuh-monitoring indices cron task
 WAZUH_MONITORING_SHARDS=2           # Configure wazuh-monitoring-* indices shards and replicas
 WAZUH_MONITORING_REPLICAS=0         #

--- a/kibana-odfe/config/wazuh_app_config.sh
+++ b/kibana-odfe/config/wazuh_app_config.sh
@@ -32,6 +32,7 @@ declare -A CONFIG_MAP=(
   [ip.selector]=$IP_SELECTOR
   [ip.ignore]=$IP_IGNORE
   [wazuh.monitoring.enabled]=$WAZUH_MONITORING_ENABLED
+  [wazuh.monitoring.creation]=$WAZUH_MONITORING_CREATION
   [wazuh.monitoring.frequency]=$WAZUH_MONITORING_FREQUENCY
   [wazuh.monitoring.shards]=$WAZUH_MONITORING_SHARDS
   [wazuh.monitoring.replicas]=$WAZUH_MONITORING_REPLICAS

--- a/kibana/config/wazuh_app_config.sh
+++ b/kibana/config/wazuh_app_config.sh
@@ -32,6 +32,7 @@ declare -A CONFIG_MAP=(
   [ip.selector]=$IP_SELECTOR
   [ip.ignore]=$IP_IGNORE
   [wazuh.monitoring.enabled]=$WAZUH_MONITORING_ENABLED
+  [wazuh.monitoring.creation]=$WAZUH_MONITORING_CREATION
   [wazuh.monitoring.frequency]=$WAZUH_MONITORING_FREQUENCY
   [wazuh.monitoring.shards]=$WAZUH_MONITORING_SHARDS
   [wazuh.monitoring.replicas]=$WAZUH_MONITORING_REPLICAS


### PR DESCRIPTION
Added environment variable `WAZUH_MONITORING_CREATION` to allow custom configuration of Kibana variable `wazuh.monitoring.creation` inside Docker container.

