### PR TITLE
allow wazuh & kibana to use multi elastic search server

### DIFF
--- a/build-from-sources.yml
+++ b/build-from-sources.yml
@@ -13,7 +13,7 @@ services:
       - "514:514/udp"
       - "55000:55000"
     environment:
-      - ELASTICSEARCH_URL=https://elasticsearch:9200
+      - ELASTICSEARCH_URL=\"https://elasticsearch:9200\",\"https://elasticsearch1:9200'\"
       - ELASTIC_USERNAME=admin
       - ELASTIC_PASSWORD=admin
       - FILEBEAT_SSL_VERIFICATION_MODE=none
@@ -58,6 +58,10 @@ services:
     ports:
       - 443:5601
     environment:
+      # check only one node health for start kibana
+      - ELASTICSEARCH_URL=https://elasticsearch:9200
+      # allow kibana connect to multi elasticsearch node
+      - ELASTICSEARCH_HOSTS=\"https://elasticsearch:9200\",\"https://elasticsearch1:9200'\"
       - ELASTICSEARCH_USERNAME=admin
       - ELASTICSEARCH_PASSWORD=admin
       - SERVER_SSL_ENABLED=true

--- a/kibana/config/entrypoint.sh
+++ b/kibana/config/entrypoint.sh
@@ -2,7 +2,7 @@
 # Wazuh Docker Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 
 set -e
-
+export ELASTICSEARCH_HOSTS="[$ELASTICSEARCH_HOSTS]"
 ##############################################################################
 # Waiting for elasticsearch
 ##############################################################################

--- a/kibana/config/kibana_settings.sh
+++ b/kibana/config/kibana_settings.sh
@@ -17,7 +17,7 @@ WAZUH_MAJOR=4
 ##############################################################################
 # Customize elasticsearch ip
 ##############################################################################
-sed -i "s|elasticsearch.hosts:.*|elasticsearch.hosts: $el_url|g" /usr/share/kibana/config/kibana.yml
+sed -i "s|elasticsearch.hosts:.*|elasticsearch.hosts: $ELASTICSEARCH_HOSTS|g" /usr/share/kibana/config/kibana.yml
 
 # If KIBANA_INDEX was set, then change the default index in kibana.yml configuration file. If there was an index, then delete it and recreate.
 if [ "$KIBANA_INDEX" != "" ]; then

--- a/production_cluster/elastic_opendistro/elasticsearch-node1.yml
+++ b/production_cluster/elastic_opendistro/elasticsearch-node1.yml
@@ -29,3 +29,5 @@ cluster.routing.allocation.disk.threshold_enabled: false
 #opendistro_security.audit.config.disabled_rest_categories: NONE
 #opendistro_security.audit.config.disabled_transport_categories: NONE
 opendistro_security.audit.log_request_body: false
+# to allow elasticsearch discovery outside docker elasticsearch enable this line (in a real project you run elasticsearch in different machines and you need this option)
+# network.publish_host: nodeDnsName Example= https://node1.dns.name

--- a/production_cluster/elastic_opendistro/elasticsearch-node2.yml
+++ b/production_cluster/elastic_opendistro/elasticsearch-node2.yml
@@ -29,3 +29,5 @@ cluster.routing.allocation.disk.threshold_enabled: false
 #opendistro_security.audit.config.disabled_rest_categories: NONE
 #opendistro_security.audit.config.disabled_transport_categories: NONE
 opendistro_security.audit.log_request_body: false
+# to allow elasticsearch discovery outside docker elasticsearch enable this line (in a real project you run elasticsearch in different machines and you need this option)
+# network.publish_host: nodeDnsName Example= https://node2.dns.name

--- a/production_cluster/elastic_opendistro/elasticsearch-node3.yml
+++ b/production_cluster/elastic_opendistro/elasticsearch-node3.yml
@@ -29,3 +29,5 @@ cluster.routing.allocation.disk.threshold_enabled: false
 #opendistro_security.audit.config.disabled_rest_categories: NONE
 #opendistro_security.audit.config.disabled_transport_categories: NONE
 opendistro_security.audit.log_request_body: false
+# to allow elasticsearch discovery outside docker elasticsearch enable this line (in a real project you run elasticsearch in different machines and you need this option)
+# network.publish_host: nodeDnsName Example= https://node3.dns.name

--- a/wazuh-odfe/config/etc/cont-init.d/1-config-filebeat
+++ b/wazuh-odfe/config/etc/cont-init.d/1-config-filebeat
@@ -5,7 +5,7 @@ set -e
 
 if [ "$ELASTICSEARCH_URL" != "" ]; then
   >&2 echo "Customize Elasticsearch ouput IP"
-  sed -i "s|hosts:.*|hosts: ['$ELASTICSEARCH_URL']|g" /etc/filebeat/filebeat.yml
+  sed -i "s|hosts:.*|hosts: [$ELASTICSEARCH_URL]|g" /etc/filebeat/filebeat.yml
 fi
 
 # Configure filebeat.yml security settings


### PR DESCRIPTION
in default, your wazuh & kibana config only connect to one elastic search node but in the real project, we need this option to allow wazuh and kibana to sync data from multi elastic search nodes for more availability of our project