### PR TITLE
Feature fix permissions

### DIFF
--- a/generate-opendistro-certs.yml
+++ b/generate-opendistro-certs.yml
@@ -5,6 +5,7 @@ services:
   generator:
     image: wazuh/opendistro-certs-generator:0.1
     hostname: opendistro-certs-generator
+    user: "${UID}:${GID}"
     volumes:
       - ./production_cluster/ssl_certs/certs.yml:/usr/src/config/myconf.yml
       - ./production_cluster/ssl_certs/:/usr/src/certs/out/ 

--- a/generate-opendistro-certs.yml
+++ b/generate-opendistro-certs.yml
@@ -5,7 +5,7 @@ services:
   generator:
     image: wazuh/opendistro-certs-generator:0.1
     hostname: opendistro-certs-generator
-    user: "${UID}:${GID}"
+    user: "${CURRENT_UID}:${CURRENT_GID}"
     volumes:
       - ./production_cluster/ssl_certs/certs.yml:/usr/src/config/myconf.yml
       - ./production_cluster/ssl_certs/:/usr/src/certs/out/ 


### PR DESCRIPTION
This simple PR fixes the invalid permissions of elastic stack during the execution of the wazuh production . 
Actually, certificates are generated by using the `generate-opendistro-certs.yml` file. It is executed as root, so it creates certificates belonging to root user. 

Every time that the elastic containers are executed, they give an error as the service runs as `elasticsearch` user that is not able to read the certificates. 

When you create the certificates, it would be useful to generate them with the `uid` equals to `elasticsearch` uid. 
By using the `user` feature it is possible to run a service with a low-privileged user. 
In that case, you can run the service that creates the certificates by using the following command: 
``` 
CURRENT_UID=`id -u` CURRENT_GID=`id -g`  docker-compose -f generate-opendistro-certs.yml run --rm generator  
```  

A consideration about the permissions: 
a best practices should preserve services from reading sensitive information such as the private 
For example, in nginx: 
* private keys belongs to `root` user and are set with 600  : only root can view and edit 
* pem certificates are required by the nginx process and are set with 644 , but belongs to `root` user : everyone can read the certificates but only root can modify them   

In elasticsearch it does not seem to be possible: 
* the execution of elastic as non-root user is ok, but it requires read permission on the key, so it is not possible to set a 600 permission with root user; 
* If you set `root` user to generated keys with read everyone permission (as now), elastic fails with errors, even if all the files have read everyone permission.
*  the `generate-opendistro-certs` image creates all the certificates with `644` permissions. 

For these conditions, we require to create  certificates and keys as `elastic` user. 
Eventually it could be possible to harden the certificates permissions by changing inside the `wazuh/opendistro-certs.generator:0.1` image. I was not able to find it, but basically is just adding an instruction that changes the permissions: 
```  
chmod 400 <certificates_in_the_path>  
```   
Anyway, it should be tested to avoid the usual elastic error in the first deployment step. 


