### PR TITLE
Update `create_user.py` script to create the RBAC database before trying to read

### DIFF
--- a/wazuh-odfe/config/create_user.py
+++ b/wazuh-odfe/config/create_user.py
@@ -13,6 +13,7 @@ SPECIAL_CHARS = "@$!%*?&-_"
 
 
 try:
+    from wazuh.rbac.orm import create_rbac_db
     from wazuh.security import (
         create_user,
         get_users,
@@ -66,6 +67,10 @@ if __name__ == "__main__":
         # abort if no user file detected
         sys.exit(0)
     username, password = read_user_file()
+
+    # create RBAC database
+    create_rbac_db()
+
     initial_users = db_users()
     if username not in initial_users:
         # create a new user


### PR DESCRIPTION
This pull request closes #574 .

The related issue reported an error found in a test where a cluster with 1 master node and 1 worker node of Wazuh manager 4.3.0 was set up.

The error showed that the RBAC DB tables did not exist. 

The RBAC DB used to be created when first importing the `orm` module. After the changes done in https://github.com/wazuh/wazuh/pull/11598, the RBAC DB creation is done in the `wazuh-apid.py` script. Therefore, no RBAC DB is created in the `create_user.py` script and when trying to access the DB information, the error is raised.

I have updated the `create_user.py` script to include a call to this function (`create_rbac_db()`).

### Test

```
root@wazuh-master:/# cat /var/ossec/api/configuration/admin.json
{
  "username": "acme-user",
  "password": "MyS3cr37P450r.*-"
}     
```

Before changes:

```
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 create_user.py
Traceback (most recent call last):
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1245, in _execute_context
    self.dialect.do_execute(
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 581, in do_execute
    cursor.execute(statement, parameters)
sqlite3.OperationalError: no such table: users

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "//create_user.py", line 74, in <module>
    initial_users = db_users()
  File "//create_user.py", line 36, in db_users
    users_result = get_users()
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/rbac/decorators.py", line 386, in wrapper
    allow = _match_permissions(req_permissions=req_permissions, rbac_mode=rbac.get()['rbac_mode'])
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/rbac/decorators.py", line 232, in _match_permissions
    rbac_mode == 'black' and _black_expansion(req_resources, allow_match)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/rbac/decorators.py", line 146, in _black_expansion
    expanded_resource = _expand_resource(chunk)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/rbac/decorators.py", line 57, in _expand_resource
    users = auth.get_users()
  File "/var/ossec/framework/python/lib/python3.9/site-packages/wazuh-4.3.0-py3.9.egg/wazuh/rbac/orm.py", line 851, in get_users
    users = self.session.query(User).all()
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 3211, in all
    return list(self)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 3367, in __iter__
    return self._execute_and_instances(context)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/orm/query.py", line 3392, in _execute_and_instances
    result = conn.execute(querycontext.statement, self._params)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 982, in execute
    return meth(self, multiparams, params)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/sql/elements.py", line 287, in _execute_on_connection
    return connection._execute_clauseelement(self, multiparams, params)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1095, in _execute_clauseelement
    ret = self._execute_context(
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1249, in _execute_context
    self._handle_dbapi_exception(
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1476, in _handle_dbapi_exception
    util.raise_from_cause(sqlalchemy_exception, exc_info)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 398, in raise_from_cause
    reraise(type(exception), exception, tb=exc_tb, cause=cause)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/util/compat.py", line 152, in reraise
    raise value.with_traceback(tb)
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/base.py", line 1245, in _execute_context
    self.dialect.do_execute(
  File "/var/ossec/framework/python/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 581, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: users
[SQL: SELECT users.id AS users_id, users.username AS users_username, users.password AS users_password, users.allow_run_as AS users_allow_run_as, users.created_at AS users_created_at 
FROM users]
(Background on this error at: http://sqlalche.me/e/e3q8)
```

After changes:

```
root@wazuh-master:/# /var/ossec/framework/python/bin/python3 create_user.py
root@wazuh-master:/# find -name rbac.db
./var/ossec/api/configuration/security/rbac.db
root@wazuh-master:/# 
```