### PR TITLE
Allow other Exceptions to bubble up a stack trace instead of silently failing in create_user.py

### DIFF
--- a/build-docker-images/wazuh-manager/config/create_user.py
+++ b/build-docker-images/wazuh-manager/config/create_user.py
@@ -21,7 +21,7 @@ try:
         set_user_role,
         update_user,
     )
-except Exception as e:
+except ModuleNotFoundError as e:
     logging.error("No module 'wazuh' found.")
     sys.exit(1)
 


### PR DESCRIPTION
I came across an issue where the `wazuh/wazuh-odfe:4.2.5` container would fail with the ambiguous error message:

```
ERROR:root:No module 'wazuh' found.
There was an error configuring the API user
```

Patching the `create_user.py` file to not have a blanket catch all exceptions allowed me to find out the real error was (likely file permissions issue):
```
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
```