### PR TITLE
Remove https nginx configuration

### DIFF
--- a/production-cluster.yml
+++ b/production-cluster.yml
@@ -140,6 +140,8 @@ services:
     image: wazuh/wazuh-dashboard:4.3.0
     hostname: wazuh.dashboard
     restart: always
+    ports:
+      - 443:443
     environment:
       - OPENSEARCH_HOSTS="https://wazuh1.indexer:9200"
       - WAZUH_API_URL="https://wazuh.master"
@@ -162,8 +164,6 @@ services:
     hostname: nginx
     restart: always
     ports:
-      - "80:80"
-      - "443:443"
       - "1514:1514"
     depends_on:
       - wazuh.master

--- a/production_cluster/nginx/nginx.conf
+++ b/production_cluster/nginx/nginx.conf
@@ -28,27 +28,6 @@ http {
     server_tokens off;
     gzip  on;
 
-    # Dashboard UI
-    server {
-        listen 80;
-        listen [::]:80;
-        return 301 https://$host:443$request_uri;
-    }
-
-    server {
-        listen 443 default_server ssl http2;
-        listen [::]:443 ssl http2;
-        ssl_certificate /etc/nginx/ssl/cert.pem;
-        ssl_certificate_key /etc/nginx/ssl/key.pem;
-        location / {
-            proxy_pass https://wazuh.dashboard:443/;
-            proxy_ssl_verify off;
-            proxy_buffer_size          128k;
-            proxy_buffers              4 256k;
-            proxy_busy_buffers_size    256k;
-        }
-    }
-
 }
 
 


### PR DESCRIPTION
This PR removes the nginx configuration to redirect Wazuh dashboard to port 443, since currently dashboard uses this port by default