### PR TITLE
Fix parse cert.yml according to wazuh_cert_tools modifications

### DIFF
--- a/indexer-certs-creator/config/entrypoint.sh
+++ b/indexer-certs-creator/config/entrypoint.sh
@@ -38,7 +38,7 @@ chmod 700 /$CERT_TOOL
 
 ## Execute cert tool and parsin cert.yml to set UID permissions
 source /$CERT_TOOL -A
-nodes_server=$( cert_parseYaml /config.yml | grep nodes_server_name | sed 's/nodes_server_name=//' )
+nodes_server=$( cert_parseYaml /config.yml | grep nodes_server__name | sed 's/nodes_server__name=//' )
 node_names=($nodes_server)
 
 echo "Moving created certificates to destination directory"


### PR DESCRIPTION
closes #613 

After the change on the wazuh_cert_tools.sh (#1443), on the improvement in the format of the config.yml, an error occurred in the generation of the certificates on the docker repository.
The cert_parseYaml function previously returned:
`nodes_indexer_name=wazuh1.indexer nodes_indexer_ip=wazuh1.indexer`
and now it returns:
`nodes_indexer__name=wazuh1.indexer nodes_indexer__ip=wazuh1.indexer`
Correct the greps in docker to parse correctly, as modified in the packages repo

### Test

Before changes:

```
fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ docker-compose -f generate-indexer-certs.yml run --rm generator
Pulling generator (wazuh/wazuh-certs-generator:0.0.1)...
0.0.1: Pulling from wazuh/wazuh-certs-generator
e0b25ef51634: Already exists
b5eb3cca99e9: Pull complete
d56f95ba5a4d: Pull complete
af31a2d2c100: Pull complete
Digest: sha256:0fa20b1cf534390249d8e6c15a7a6cd4cd4fbe416010be8d136062042fdc0dbd
Status: Downloaded newer image for wazuh/wazuh-certs-generator:0.0.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24863  100 24863    0     0  92772      0 --:--:-- --:--:-- --:--:-- 92772
Cert tool exists in Packages-dev bucket
12/04/2022 15:49:37 INFO: Admin certificates created.
12/04/2022 15:49:37 INFO: Wazuh indexer certificates created.
12/04/2022 15:49:37 INFO: Wazuh server certificates created.
12/04/2022 15:49:38 INFO: Wazuh dashboard certificates created.
Moving created certificates to destination directory
changing certificate permissions
Setting UID indexer and dashboard
Setting UID for wazuh manager and worker
fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ ls -la config/wazuh_indexer_ssl_certs/
total 84
dr-x------ 2 fcaffieri        fcaffieri 4096 abr 12 12:49 .
drwxrwxr-x 7 fcaffieri        fcaffieri 4096 abr 12 10:43 ..
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 admin-key.pem
-r-------- 1 fcaffieri        fcaffieri 1119 abr 12 12:49 admin.pem
-r-------- 1 fcaffieri        fcaffieri  531 abr 12 10:43 certs.yml
-r-------- 1 fcaffieri        fcaffieri 1708 abr 12 12:49 root-ca.key
-r-------- 1 systemd-coredump       997 1708 abr 12 12:49 root-ca-manager.key
-r-------- 1 systemd-coredump       997 1204 abr 12 12:49 root-ca-manager.pem
-r-------- 1 fcaffieri        fcaffieri 1204 abr 12 12:49 root-ca.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 wazuh1.indexer-key.pem
-r-------- 1 fcaffieri        fcaffieri 1257 abr 12 12:49 wazuh1.indexer.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 wazuh2.indexer-key.pem
-r-------- 1 fcaffieri        fcaffieri 1257 abr 12 12:49 wazuh2.indexer.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 wazuh3.indexer-key.pem
-r-------- 1 fcaffieri        fcaffieri 1257 abr 12 12:49 wazuh3.indexer.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 wazuh.dashboard-key.pem
-r-------- 1 fcaffieri        fcaffieri 1261 abr 12 12:49 wazuh.dashboard.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 wazuh.master-key.pem
-r-------- 1 fcaffieri        fcaffieri 1253 abr 12 12:49 wazuh.master.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:49 wazuh.worker-key.pem
-r-------- 1 fcaffieri        fcaffieri 1253 abr 12 12:49 wazuh.worker.pem

```

After changes:

```
fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ docker image rm -f wazuh/wazuh-certs-generator:0.0.1
Untagged: wazuh/wazuh-certs-generator:0.0.1
Untagged: wazuh/wazuh-certs-generator@sha256:0fa20b1cf534390249d8e6c15a7a6cd4cd4fbe416010be8d136062042fdc0dbd
Deleted: sha256:fcd66eda3665acaf5bd788d53a8c74a0a2e58ac53a41b7de042e6b3924f2af13
Deleted: sha256:66896fe6595a4aca00b2fea140307415348f47582fdb52141b909c99c4c818e7
Deleted: sha256:7158626e306deec858bc27e8e4f46a39f8fe94d34231ce6e2e5743d2a6cb14b7
Deleted: sha256:67d1bdfe9540b5898475e81d5195634b70e6cd57db0143e0ea20e53b96660a60

fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ sudo rm -rf config/wazuh_indexer_ssl_certs/*.pem
fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ sudo rm -rf config/wazuh_indexer_ssl_certs/*.key

fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ docker build -t wazuh/wazuh-certs-generator:0.0.1 ../indexer-certs-creator/
Sending build context to Docker daemon  6.656kB
Step 1/6 : FROM ubuntu:focal
 ---> 825d55fb6340
Step 2/6 : RUN apt-get update && apt-get install openssl curl -y
 ---> Running in 2595cabbf352
Step 3/6 : WORKDIR /
 ---> Running in 9c74159cbe7c
Removing intermediate container 9c74159cbe7c
 ---> 859a7d9f29a2
Step 4/6 : COPY config/entrypoint.sh /
 ---> e0ffea099677
Step 5/6 : RUN chmod 700 /entrypoint.sh
 ---> Running in 4935146205ee
Removing intermediate container 4935146205ee
 ---> c304f3b929e3
Step 6/6 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Running in 814e6e62fadb
Removing intermediate container 814e6e62fadb
 ---> f58142fc8529
Successfully built f58142fc8529
Successfully tagged wazuh/wazuh-certs-generator:0.0.1
fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ docker-compose -f generate-indexer-certs.yml run --rm generator
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 24863  100 24863    0     0  27054      0 --:--:-- --:--:-- --:--:-- 27025
Cert tool exists in Packages-dev bucket
12/04/2022 15:52:34 INFO: Admin certificates created.
12/04/2022 15:52:34 INFO: Wazuh indexer certificates created.
12/04/2022 15:52:34 INFO: Wazuh server certificates created.
12/04/2022 15:52:34 INFO: Wazuh dashboard certificates created.
Moving created certificates to destination directory
changing certificate permissions
Setting UID indexer and dashboard
Setting UID for wazuh manager and worker

fcaffieri@Fede:~/repos/wazuh-docker/multi-node$ ls -la config/wazuh_indexer_ssl_certs/
total 84
dr-x------ 2 fcaffieri        fcaffieri 4096 abr 12 12:52 .
drwxrwxr-x 7 fcaffieri        fcaffieri 4096 abr 12 10:43 ..
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:52 admin-key.pem
-r-------- 1 fcaffieri        fcaffieri 1119 abr 12 12:52 admin.pem
-r-------- 1 fcaffieri        fcaffieri  531 abr 12 10:43 certs.yml
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:52 root-ca.key
-r-------- 1 systemd-coredump       997 1704 abr 12 12:52 root-ca-manager.key
-r-------- 1 systemd-coredump       997 1204 abr 12 12:52 root-ca-manager.pem
-r-------- 1 fcaffieri        fcaffieri 1204 abr 12 12:52 root-ca.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:52 wazuh1.indexer-key.pem
-r-------- 1 fcaffieri        fcaffieri 1257 abr 12 12:52 wazuh1.indexer.pem
-r-------- 1 fcaffieri        fcaffieri 1708 abr 12 12:52 wazuh2.indexer-key.pem
-r-------- 1 fcaffieri        fcaffieri 1257 abr 12 12:52 wazuh2.indexer.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:52 wazuh3.indexer-key.pem
-r-------- 1 fcaffieri        fcaffieri 1257 abr 12 12:52 wazuh3.indexer.pem
-r-------- 1 fcaffieri        fcaffieri 1704 abr 12 12:52 wazuh.dashboard-key.pem
-r-------- 1 fcaffieri        fcaffieri 1261 abr 12 12:52 wazuh.dashboard.pem
-r-------- 1 systemd-coredump       997 1704 abr 12 12:52 wazuh.master-key.pem
-r-------- 1 systemd-coredump       997 1253 abr 12 12:52 wazuh.master.pem
-r-------- 1 systemd-coredump       997 1704 abr 12 12:52 wazuh.worker-key.pem
-r-------- 1 systemd-coredump       997 1253 abr 12 12:52 wazuh.worker.pem

```