### PR TITLE
Fix whitelist in 4.4

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -222,7 +222,6 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>127.0.0.53</white_list>
   </global>
 
   <command>

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -222,9 +222,6 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>4.4.0.1</white_list>
-    <white_list>4.4.0.2</white_list>
-    <white_list>208.67.220.220</white_list>
   </global>
 
   <command>

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -222,9 +222,6 @@
   <global>
     <white_list>127.0.0.1</white_list>
     <white_list>^localhost.localdomain$</white_list>
-    <white_list>4.4.0.1</white_list>
-    <white_list>4.4.0.2</white_list>
-    <white_list>208.67.220.220</white_list>
   </global>
 
   <command>


### PR DESCRIPTION
This PR eliminates the whitelist lines that are not necessary for the deployment of the stacks.