### PR TITLE
Add option to recreate keystore in entrypoint

### DIFF
--- a/build-docker-images/wazuh-dashboard/config/entrypoint.sh
+++ b/build-docker-images/wazuh-dashboard/config/entrypoint.sh
@@ -7,7 +7,7 @@ DASHBOARD_PASSWORD="${DASHBOARD_PASSWORD:-kibanaserver}"
 
 # Create and configure Wazuh dashboard keystore
 
-$INSTALL_DIR/bin/opensearch-dashboards-keystore create --allow-root && \
+yes | $INSTALL_DIR/bin/opensearch-dashboards-keystore create --allow-root && \
 echo $DASHBOARD_USERNAME | $INSTALL_DIR/bin/opensearch-dashboards-keystore add opensearch.username --stdin --allow-root && \
 echo $DASHBOARD_PASSWORD | $INSTALL_DIR/bin/opensearch-dashboards-keystore add opensearch.password --stdin --allow-root
 


### PR DESCRIPTION
This PR fix the creation of the keystore in the Wazuh dashboard entrypoint accepting the recreate command if it already exists