### PR TITLE
Add Double Quote on password

### DIFF
--- a/multi-node/config/wazuh_dashboard/wazuh.yml
+++ b/multi-node/config/wazuh_dashboard/wazuh.yml
@@ -3,5 +3,5 @@ hosts:
       url: "https://wazuh.master"
       port: 55000
       username: wazuh-wui
-      password: MyS3cr37P450r.*-
+      password: "MyS3cr37P450r.*-"
       run_as: false

--- a/single-node/config/wazuh_dashboard/wazuh.yml
+++ b/single-node/config/wazuh_dashboard/wazuh.yml
@@ -3,5 +3,5 @@ hosts:
       url: "https://wazuh.manager"
       port: 55000
       username: wazuh-wui
-      password: MyS3cr37P450r.*-
+      password: "MyS3cr37P450r.*-"
       run_as: false


### PR DESCRIPTION
This PR adds a double quote on Wazuh API password into single and multi node deployment
Closes https://github.com/wazuh/wazuh-docker/issues/714
