### PR TITLE
Remove queue_size tag

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -28,7 +28,6 @@
     <connection>secure</connection>
     <port>1514</port>
     <protocol>tcp</protocol>
-    <queue_size>131072</queue_size>
   </remote>
 
   <!-- Policy monitoring -->

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -28,7 +28,6 @@
     <connection>secure</connection>
     <port>1514</port>
     <protocol>tcp</protocol>
-    <queue_size>131072</queue_size>
   </remote>
 
   <!-- Policy monitoring -->

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -28,7 +28,6 @@
     <connection>secure</connection>
     <port>1514</port>
     <protocol>tcp</protocol>
-    <queue_size>131072</queue_size>
   </remote>
 
   <!-- Policy monitoring -->


### PR DESCRIPTION
This PR removes queue_size tag into ossec.conf because this tag will deprecate in 4.4.
Related Issue https://github.com/wazuh/wazuh-docker/issues/748