### PR TITLE
Update docker-compose.yml

### DIFF
--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -70,8 +70,8 @@ services:
     ports:
       - 443:5601
     environment:
-      - INDEXER_USERNAME=admin
-      - INDEXER_PASSWORD=SecretPassword
+      - DASHBOARD_USERNAME=kibanaserver
+      - DASHBOARD_PASSWORD=kibanaserver
       - WAZUH_API_URL=https://wazuh.manager
       - API_USERNAME=wazuh-wui
       - API_PASSWORD=MyS3cr37P450r.*-


### PR DESCRIPTION
The current docker-compose uses the wrong environment variable names in dashboard container. dashboard will set indexer password and username (opensearch.password, opensearch.username) to kibanaserver/kibanaserver by default. Trying to change the password will result in constant failure to connect. 

Changed: 
INDEXER_USERNAME -> DASHBOARD_USERNAME
INDEXER_PASSWORD -> DASHBOARD_PASSWORD