### PR TITLE
Added 'python3-requests' package to wazuh-manager Dockerfile

### DIFF
--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -10,7 +10,7 @@ ARG FILEBEAT_CHANNEL=filebeat-oss
 ARG FILEBEAT_VERSION=7.10.2
 ARG WAZUH_FILEBEAT_MODULE="wazuh-filebeat-0.2.tar.gz"
 
-RUN apt-get update && apt install curl apt-transport-https lsb-release gnupg -y
+RUN apt-get update && apt install curl apt-transport-https lsb-release gnupg python3-requests -y
 
 COPY config/check_repository.sh /
 


### PR DESCRIPTION
Some integrations like Slack require the python3-requests module to send notifications.
However, this module is not included in the wazuh-manager image.

More Information:
https://github.com/wazuh/wazuh-docker/issues/788