### PR TITLE
Remove unnecessarily exposed ports in single-node docker-compose.yml …

### DIFF
--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "1514:1514"
       - "1515:1515"
       - "514:514/udp"
-      - "55000:55000"
     environment:
       - INDEXER_URL=https://wazuh.indexer:9200
       - INDEXER_USERNAME=admin
@@ -42,8 +41,6 @@ services:
     image: wazuh/wazuh-indexer:4.8.0
     hostname: wazuh.indexer
     restart: always
-    ports:
-      - "9200:9200"
     environment:
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
     ulimits:


### PR DESCRIPTION
As far as I can tell it is not necessary to expose these ports to have a working Wazuh server.
The dashboard communicates with the indexer and manager via the internal docker network. The exposed ports are only needed to view the dashboard (443) and for agents to connect remotely (1514,1515,514).
Am I missing something?