### PR TITLE
Fixed conditional block in images building

### DIFF
--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -3,13 +3,6 @@ WAZUH_VERSION=$(echo $WAZUH_IMAGE_VERSION | sed -e 's/\.//g')
 WAZUH_TAG_REVISION=1
 WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2- | sed -e 's/\.//g')
 
-## If wazuh manager exists in apt dev repository, change variables, if not, exit 1
-if [ "$WAZUH_VERSION" -le "$WAZUH_CURRENT_VERSION" ]; then
-  IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
-else
-  IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
-fi
-
 echo WAZUH_VERSION=$WAZUH_IMAGE_VERSION > .env
 echo WAZUH_IMAGE_VERSION=$IMAGE_VERSION >> .env
 echo WAZUH_TAG_REVISION=$WAZUH_TAG_REVISION >> .env


### PR DESCRIPTION
# Description

Closes: #917 
The aim of this PR is to remove the conditional block in the `build-docker-images/build-images.sh` script, which was useless.

```bash
if [ "$WAZUH_VERSION" -le "$WAZUH_CURRENT_VERSION" ]; then
  IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
else
  IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
fi
```