### PR TITLE
Updating vulnerability detector default configuration with AlmaLinux support

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -150,6 +150,14 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- Alma Linux OS vulnerabilities -->
+    <provider name="almalinux">
+      <enabled>no</enabled>
+      <os>8</os>
+      <os>9</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Aggregate vulnerabilities -->
     <provider name="nvd">
       <enabled>yes</enabled>

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -144,6 +144,14 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- Alma Linux OS vulnerabilities -->
+    <provider name="almalinux">
+      <enabled>no</enabled>
+      <os>8</os>
+      <os>9</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Windows OS vulnerabilities -->
     <provider name="msu">
       <enabled>yes</enabled>

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -144,6 +144,14 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- Alma Linux OS vulnerabilities -->
+    <provider name="almalinux">
+      <enabled>no</enabled>
+      <os>8</os>
+      <os>9</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Windows OS vulnerabilities -->
     <provider name="msu">
       <enabled>yes</enabled>


### PR DESCRIPTION
## Description

This PR adds the corresponding AlmaLinux entry in the vulnerability detector default configuration after the changes in [Add support for AlmaLinux in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/16343#top)
#16343.

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new AlmaLinux provider