### PR TITLE
Update the vulnerability detector default configuration block with missing providers

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -138,6 +138,18 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- SUSE Linux Enterprise OS vulnerabilities -->
+    <provider name="suse">
+      <enabled>no</enabled>
+      <os>11-server</os>
+      <os>11-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>15-server</os>
+      <os>15-desktop</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Arch OS vulnerabilities -->
     <provider name="arch">
       <enabled>no</enabled>

--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -114,7 +114,6 @@
     <!-- Debian OS vulnerabilities -->
     <provider name="debian">
       <enabled>no</enabled>
-      <os>stretch</os>
       <os>buster</os>
       <os>bullseye</os>
       <update_interval>1h</update_interval>
@@ -127,6 +126,7 @@
       <os>6</os>
       <os>7</os>
       <os>8</os>
+      <os>9</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -108,6 +108,7 @@
       <os>xenial</os>
       <os>bionic</os>
       <os>focal</os>
+      <os>jammy</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -138,6 +138,18 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- SUSE Linux Enterprise OS vulnerabilities -->
+    <provider name="suse">
+      <enabled>no</enabled>
+      <os>11-server</os>
+      <os>11-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>15-server</os>
+      <os>15-desktop</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Arch OS vulnerabilities -->
     <provider name="arch">
       <enabled>no</enabled>

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -114,7 +114,6 @@
     <!-- Debian OS vulnerabilities -->
     <provider name="debian">
       <enabled>no</enabled>
-      <os>stretch</os>
       <os>buster</os>
       <os>bullseye</os>
       <update_interval>1h</update_interval>
@@ -127,6 +126,7 @@
       <os>6</os>
       <os>7</os>
       <os>8</os>
+      <os>9</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -108,6 +108,7 @@
       <os>xenial</os>
       <os>bionic</os>
       <os>focal</os>
+      <os>jammy</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -138,6 +138,18 @@
       <update_interval>1h</update_interval>
     </provider>
 
+    <!-- SUSE Linux Enterprise OS vulnerabilities -->
+    <provider name="suse">
+      <enabled>no</enabled>
+      <os>11-server</os>
+      <os>11-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>15-server</os>
+      <os>15-desktop</os>
+      <update_interval>1h</update_interval>
+    </provider>
+
     <!-- Arch OS vulnerabilities -->
     <provider name="arch">
       <enabled>no</enabled>

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -114,7 +114,6 @@
     <!-- Debian OS vulnerabilities -->
     <provider name="debian">
       <enabled>no</enabled>
-      <os>stretch</os>
       <os>buster</os>
       <os>bullseye</os>
       <update_interval>1h</update_interval>
@@ -127,6 +126,7 @@
       <os>6</os>
       <os>7</os>
       <os>8</os>
+      <os>9</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -108,6 +108,7 @@
       <os>xenial</os>
       <os>bionic</os>
       <os>focal</os>
+      <os>jammy</os>
       <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
This PR adds SUSE to the vulnerability detector configuration.
Closes https://github.com/wazuh/wazuh-docker/issues/926