### PR TITLE
Add Debian Bookworm to VDT default configuration

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -117,6 +117,7 @@
       <enabled>no</enabled>
       <os>buster</os>
       <os>bullseye</os>
+      <os>bookworm</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -117,6 +117,7 @@
       <enabled>no</enabled>
       <os>buster</os>
       <os>bullseye</os>
+      <os>bookworm</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -117,6 +117,7 @@
       <enabled>no</enabled>
       <os>buster</os>
       <os>bullseye</os>
+      <os>bookworm</os>
       <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#18516|

## Description

This PR adds the corresponding Debian Bookworm entry in the vulnerability detector default configuration after the changes in [Add support for Debian Bookworm in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/18516)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Debian Bookworm provider