### PR TITLE
Add Amazon Linux 2023 VDT default configuration

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -136,6 +136,7 @@
       <enabled>no</enabled>
       <os>amazon-linux</os>
       <os>amazon-linux-2</os>
+      <os>amazon-linux-2023</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -136,6 +136,7 @@
       <enabled>no</enabled>
       <os>amazon-linux</os>
       <os>amazon-linux-2</os>
+      <os>amazon-linux-2023</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/single-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/single-node/config/wazuh_cluster/wazuh_manager.conf
@@ -136,6 +136,7 @@
       <enabled>no</enabled>
       <os>amazon-linux</os>
       <os>amazon-linux-2</os>
+      <os>amazon-linux-2023</os>
       <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#17617|

## Description

This PR adds the corresponding Amazon Linux 2023 entry in the vulnerability detector default configuration after the changes in [Add support for Amazon Linux 2023 in Vulnerability Detector](https://github.com/wazuh/wazuh/issues/17617)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Amazon Linux 2023 provider