### PR TITLE
Updated file permissions to have the same permissions as in package installation in Wazuh indexer

### DIFF
--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -144,3 +144,13 @@ find ${TARGET_DIR} -type f -perm 644 -exec chmod 640 {} \;
 find ${TARGET_DIR} -type f -perm 664 -exec chmod 660 {} \;
 find ${TARGET_DIR} -type f -perm 755 -exec chmod 750 {} \;
 find ${TARGET_DIR} -type f -perm 744 -exec chmod 740 {} \;
+
+chmod -R 0700 ${TARGET_DIR}/.cache
+chmod 0700 ${TARGET_DIR}/extensions
+chmod 0700 ${TARGET_DIR}/logs
+chmod 0600 ${TARGET_DIR}/opensearch.yml
+find ${TARGET_DIR}/bin -type f -exec chmod 0600 {} \;
+find ${TARGET_DIR}/jdk/bin -type f -exec chmod 0600 {} \;
+chmod 0600 ${TARGET_DIR}/opensearch-security/internal_users.yml
+find ${TARGET_DIR}/performance-analyzer-rca/bin -type f -exec chmod 0600 {} \;
+chmod 0600 ${TARGET_DIR}/plugins/opensearch-security/tools/wazuh-certs-tool.sh

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -133,7 +133,7 @@ cp -pr /wazuh-certificates/admin-key.pem ${TARGET_DIR}${CONFIG_DIR}/certs/admin-
 # Delete xms and xmx parameters in jvm.options
 sed '/-Xms/d' -i ${TARGET_DIR}${CONFIG_DIR}/jvm.options
 sed '/-Xmx/d' -i ${TARGET_DIR}${CONFIG_DIR}/jvm.options
-sed -i '|-Djava.security.policy=file:\/\/\/etc\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy|-Djava.security.policy=file:\/\/\/usr\/share\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy|' ${TARGET_DIR}${CONFIG_DIR}/jvm.options
+sed -i 's/-Djava.security.policy=file:\/\/\/etc\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy/-Djava.security.policy=file:\/\/\/usr\/share\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy/g' ${TARGET_DIR}${CONFIG_DIR}/jvm.options
 
 
 chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -144,13 +144,3 @@ find ${TARGET_DIR} -type f -perm 644 -exec chmod 640 {} \;
 find ${TARGET_DIR} -type f -perm 664 -exec chmod 660 {} \;
 find ${TARGET_DIR} -type f -perm 755 -exec chmod 750 {} \;
 find ${TARGET_DIR} -type f -perm 744 -exec chmod 740 {} \;
-
-chmod -R 0700 ${TARGET_DIR}/.cache
-chmod 0700 ${TARGET_DIR}/extensions
-chmod 0700 ${TARGET_DIR}/logs
-chmod 0600 ${TARGET_DIR}/opensearch.yml
-find ${TARGET_DIR}/bin -type f -exec chmod 0600 {} \;
-find ${TARGET_DIR}/jdk/bin -type f -exec chmod 0600 {} \;
-chmod 0600 ${TARGET_DIR}/opensearch-security/internal_users.yml
-find ${TARGET_DIR}/performance-analyzer-rca/bin -type f -exec chmod 0600 {} \;
-chmod 0600 ${TARGET_DIR}/plugins/opensearch-security/tools/wazuh-certs-tool.sh

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -144,3 +144,10 @@ find ${TARGET_DIR} -type f -perm 644 -exec chmod 640 {} \;
 find ${TARGET_DIR} -type f -perm 664 -exec chmod 660 {} \;
 find ${TARGET_DIR} -type f -perm 755 -exec chmod 750 {} \;
 find ${TARGET_DIR} -type f -perm 744 -exec chmod 740 {} \;
+
+
+# Fix OpenSearch security plugin permissions
+chown ${USER}:${GROUP} ${TARGET_DIR}${INSTALLATION_DIR}/opensearch-security/internal_users.yml
+chown ${USER}:${GROUP} ${TARGET_DIR}${CONFIG_DIR}/opensearch.yml
+chmod 0600 ${TARGET_DIR}${CONFIG_DIR}/opensearch.yml
+chmod 0600 ${TARGET_DIR}${INSTALLATION_DIR}/opensearch-security/internal_users.yml

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -133,6 +133,8 @@ cp -pr /wazuh-certificates/admin-key.pem ${TARGET_DIR}${CONFIG_DIR}/certs/admin-
 # Delete xms and xmx parameters in jvm.options
 sed '/-Xms/d' -i ${TARGET_DIR}${CONFIG_DIR}/jvm.options
 sed '/-Xmx/d' -i ${TARGET_DIR}${CONFIG_DIR}/jvm.options
+sed -i '|-Djava.security.policy=file:\/\/\/etc\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy|-Djava.security.policy=file:\/\/\/usr\/share\/wazuh-indexer\/opensearch-performance-analyzer\/opensearch_security.policy|' ${TARGET_DIR}${CONFIG_DIR}/jvm.options
+
 
 chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs
 chmod -R 400 ${TARGET_DIR}${CONFIG_DIR}/certs/*

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -144,10 +144,3 @@ find ${TARGET_DIR} -type f -perm 644 -exec chmod 640 {} \;
 find ${TARGET_DIR} -type f -perm 664 -exec chmod 660 {} \;
 find ${TARGET_DIR} -type f -perm 755 -exec chmod 750 {} \;
 find ${TARGET_DIR} -type f -perm 744 -exec chmod 740 {} \;
-
-
-# Fix OpenSearch security plugin permissions
-chown ${USER}:${GROUP} ${TARGET_DIR}${INSTALLATION_DIR}/opensearch-security/internal_users.yml
-chown ${USER}:${GROUP} ${TARGET_DIR}${CONFIG_DIR}/opensearch.yml
-chmod 0600 ${TARGET_DIR}${CONFIG_DIR}/opensearch.yml
-chmod 0600 ${TARGET_DIR}${INSTALLATION_DIR}/opensearch-security/internal_users.yml

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -136,3 +136,9 @@ sed '/-Xmx/d' -i ${TARGET_DIR}${CONFIG_DIR}/jvm.options
 
 chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs
 chmod -R 400 ${TARGET_DIR}${CONFIG_DIR}/certs/*
+
+find ${TARGET_DIR} -type d -exec chmod 750 {} \;
+find ${TARGET_DIR} -type f -perm 644 -exec chmod 640 {} \;
+find ${TARGET_DIR} -type f -perm 664 -exec chmod 660 {} \;
+find ${TARGET_DIR} -type f -perm 755 -exec chmod 750 {} \;
+find ${TARGET_DIR} -type f -perm 744 -exec chmod 740 {} \;

--- a/build-docker-images/wazuh-indexer/config/entrypoint.sh
+++ b/build-docker-images/wazuh-indexer/config/entrypoint.sh
@@ -13,20 +13,6 @@ export CACERT=$(grep -oP "(?<=plugins.security.ssl.transport.pemtrustedcas_filep
 export CERT="${OPENSEARCH_PATH_CONF}/certs/admin.pem"
 export KEY="${OPENSEARCH_PATH_CONF}/certs/admin-key.pem"
 
-
-# Fix OpenSearch security plugin permissions
-
-chmod -R 0700 ${TARGET_DIR}/.cache
-chmod 0700 ${TARGET_DIR}/extensions
-chmod 0700 ${TARGET_DIR}/logs
-chmod 0600 ${TARGET_DIR}/opensearch.yml
-find ${TARGET_DIR}/bin -type f -exec chmod 0600 {} \;
-find ${TARGET_DIR}/jdk/bin -type f -exec chmod 0600 {} \;
-chmod 0600 ${TARGET_DIR}/opensearch-security/internal_users.yml
-find ${TARGET_DIR}/performance-analyzer-rca/bin -type f -exec chmod 0600 {} \;
-chmod 0600 ${TARGET_DIR}/plugins/opensearch-security/tools/wazuh-certs-tool.sh
-
-
 run_as_other_user_if_needed() {
   if [[ "$(id -u)" == "0" ]]; then
     # If running as root, drop to specified UID and run command

--- a/build-docker-images/wazuh-indexer/config/entrypoint.sh
+++ b/build-docker-images/wazuh-indexer/config/entrypoint.sh
@@ -13,6 +13,20 @@ export CACERT=$(grep -oP "(?<=plugins.security.ssl.transport.pemtrustedcas_filep
 export CERT="${OPENSEARCH_PATH_CONF}/certs/admin.pem"
 export KEY="${OPENSEARCH_PATH_CONF}/certs/admin-key.pem"
 
+
+# Fix OpenSearch security plugin permissions
+
+chmod -R 0700 ${TARGET_DIR}/.cache
+chmod 0700 ${TARGET_DIR}/extensions
+chmod 0700 ${TARGET_DIR}/logs
+chmod 0600 ${TARGET_DIR}/opensearch.yml
+find ${TARGET_DIR}/bin -type f -exec chmod 0600 {} \;
+find ${TARGET_DIR}/jdk/bin -type f -exec chmod 0600 {} \;
+chmod 0600 ${TARGET_DIR}/opensearch-security/internal_users.yml
+find ${TARGET_DIR}/performance-analyzer-rca/bin -type f -exec chmod 0600 {} \;
+chmod 0600 ${TARGET_DIR}/plugins/opensearch-security/tools/wazuh-certs-tool.sh
+
+
 run_as_other_user_if_needed() {
   if [[ "$(id -u)" == "0" ]]; then
     # If running as root, drop to specified UID and run command


### PR DESCRIPTION
closes https://github.com/wazuh/wazuh-docker/issues/1017

This PR aims to level file permissions between the per-package and per-docker installation of Wazun indexer, leaving the same permissions on the files.

The configuration path of the security policies is also corrected


<details>
<summary>Build images</summary>

```console
[root@centos7-1 ~]# git clone https://github.com/wazuh/wazuh-docker.git -b bug/1017-warning-opensearchsecurityplugin-wazuh-indexer-has-insecure-file-permissions-should-be-0600-to4.6.0
Cloning into 'wazuh-docker'...
remote: Enumerating objects: 11321, done.
remote: Counting objects: 100% (1360/1360), done.
remote: Compressing objects: 100% (685/685), done.
remote: Total 11321 (delta 731), reused 1206 (delta 603), pack-reused 9961
Receiving objects: 100% (11321/11321), 314.01 MiB | 9.38 MiB/s, done.
Resolving deltas: 100% (5808/5808), done.
[root@centos7-1 ~]# cd wazuh-docker/ && vi build-docker-images/wazuh-manager/Dockerfile
[root@centos7-1 wazuh-docker]# build-docker-images/build-images.sh
[+] Building 204.3s (80/80) FINISHED                                                                                                                                                                              
 => [wazuh/wazuh-indexer:4.6.0 internal] load build definition from Dockerfile                                                                                                                               0.0s
 => => transferring dockerfile: 2.44kB                                                                                                                                                                       0.0s
 => [wazuh/wazuh-indexer:4.6.0 internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                              0.0s
 => [wazuh/wazuh-manager:4.6.0 internal] load build definition from Dockerfile                                                                                                                               0.0s
 => => transferring dockerfile: 2.16kB                                                                                                                                                                       0.0s
 => [wazuh/wazuh-manager:4.6.0 internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                              0.0s
 => [wazuh/wazuh-dashboard:4.6.0 internal] load .dockerignore                                                                                                                                                0.0s
 => => transferring context: 2B                                                                                                                                                                              0.0s
 => [wazuh/wazuh-dashboard:4.6.0 internal] load build definition from Dockerfile                                                                                                                             0.0s
 => => transferring dockerfile: 3.73kB                                                                                                                                                                       0.0s
 => [wazuh/wazuh-dashboard:4.6.0 internal] load metadata for docker.io/library/ubuntu:focal                                                                                                                  2.1s
 => [wazuh/wazuh-manager:4.6.0] https://raw.githubusercontent.com/wazuh/wazuh/4.6.0/extensions/elasticsearch/7.x/wazuh-template.json                                                                         0.3s
 => [wazuh/wazuh-manager:4.6.0 internal] load build context                                                                                                                                                  0.0s
 => => transferring context: 26.20kB                                                                                                                                                                         0.0s
 => [wazuh/wazuh-dashboard:4.6.0  1/17] FROM docker.io/library/ubuntu:focal@sha256:33a5cc25d22c45900796a1aca487ad7a7cb09f09ea00b779e3b2026b4fc2faba                                                          5.3s
 => => resolve docker.io/library/ubuntu:focal@sha256:33a5cc25d22c45900796a1aca487ad7a7cb09f09ea00b779e3b2026b4fc2faba                                                                                        0.0s
 => => sha256:33a5cc25d22c45900796a1aca487ad7a7cb09f09ea00b779e3b2026b4fc2faba 1.13kB / 1.13kB                                                                                                               0.0s
 => => sha256:3246518d9735254519e1b2ff35f95686e4a5011c90c85344c1f38df7bae9dd37 424B / 424B                                                                                                                   0.0s
 => => sha256:6df89402372646d400cf092016c28066391a26f5d46c00b1153e75003465484d 2.30kB / 2.30kB                                                                                                               0.0s
 => => sha256:edaedc954fb53f42a7754a6e2d1b57f091bc9b11063bc445c2e325ea448f8f68 27.51MB / 27.51MB                                                                                                             3.2s
 => => extracting sha256:edaedc954fb53f42a7754a6e2d1b57f091bc9b11063bc445c2e325ea448f8f68                                                                                                                    1.9s
 => [wazuh/wazuh-indexer:4.6.0 internal] load build context                                                                                                                                                  0.0s
 => => transferring context: 21.25kB                                                                                                                                                                         0.0s
 => [wazuh/wazuh-dashboard:4.6.0 internal] load build context                                                                                                                                                0.0s
 => => transferring context: 14.06kB                                                                                                                                                                         0.0s
 => [wazuh/wazuh-dashboard:4.6.0 builder  2/17] RUN apt-get update && apt install curl libcap2-bin xz-utils -y                                                                                              26.5s
 => [wazuh/wazuh-indexer:4.6.0 builder 2/9] RUN apt-get update -y && apt-get install curl openssl xz-utils -y                                                                                               22.2s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  2/13] RUN apt update && apt install -y libnss3-dev fonts-liberation libfontconfig1                                                                                19.8s
 => [wazuh/wazuh-manager:4.6.0  2/17] RUN rm /bin/sh && ln -s /bin/bash /bin/sh                                                                                                                              0.6s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  2/14] RUN getent group wazuh-indexer || groupadd -r -g 1000 wazuh-indexer                                                                                            0.6s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  3/14] RUN useradd --system             --uid 1000             --no-create-home             --home-dir /usr/share/wazuh-indexer             --gid wazuh-indexer       0.6s
 => [wazuh/wazuh-manager:4.6.0  3/17] RUN apt-get update && apt install curl apt-transport-https lsb-release gnupg -y                                                                                       26.6s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  4/14] WORKDIR /usr/share/wazuh-indexer                                                                                                                               0.0s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  5/14] COPY config/entrypoint.sh /                                                                                                                                    0.0s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  6/14] COPY config/securityadmin.sh /                                                                                                                                 0.0s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  7/14] RUN chmod 700 /entrypoint.sh && chmod 700 /securityadmin.sh                                                                                                    0.2s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  8/14] RUN chown 1000:1000 /*.sh                                                                                                                                      0.3s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  3/13] RUN getent group wazuh-dashboard || groupadd -r -g 1000 wazuh-dashboard                                                                                      0.3s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  4/13] RUN useradd --system             --uid 1000             --no-create-home             --home-dir /usr/share/wazuh-dashboard             --gid wazuh-dashboar  0.3s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  5/13] COPY config/entrypoint.sh /                                                                                                                                  0.0s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  6/13] COPY config/wazuh_app_config.sh /                                                                                                                            0.0s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  7/13] RUN chmod 700 /entrypoint.sh                                                                                                                                 0.2s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  8/13] RUN chmod 700 /wazuh_app_config.sh                                                                                                                           0.2s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1  9/13] RUN chown 1000:1000 /*.sh                                                                                                                                    0.3s
 => [wazuh/wazuh-indexer:4.6.0 builder 3/9] COPY config/opensearch.yml /                                                                                                                                     0.0s
 => [wazuh/wazuh-indexer:4.6.0 builder 4/9] COPY config/config.sh .                                                                                                                                          0.0s
 => [wazuh/wazuh-indexer:4.6.0 builder 5/9] COPY config/config.yml /                                                                                                                                         0.1s
 => [wazuh/wazuh-indexer:4.6.0 builder 6/9] COPY config/internal_users.yml /                                                                                                                                 0.0s
 => [wazuh/wazuh-indexer:4.6.0 builder 7/9] COPY config/roles_mapping.yml /                                                                                                                                  0.0s
 => [wazuh/wazuh-indexer:4.6.0 builder 8/9] COPY config/roles.yml /                                                                                                                                          0.0s
 => [wazuh/wazuh-indexer:4.6.0 builder 9/9] RUN bash config.sh                                                                                                                                             147.2s
 => [wazuh/wazuh-dashboard:4.6.0 builder  3/17] RUN mkdir -p /usr/share/wazuh-dashboard                                                                                                                      0.4s
 => [wazuh/wazuh-dashboard:4.6.0 builder  4/17] COPY config/dl_base.sh .                                                                                                                                     0.1s
 => [wazuh/wazuh-dashboard:4.6.0 builder  5/17] RUN bash dl_base.sh                                                                                                                                         47.5s
 => [wazuh/wazuh-manager:4.6.0  4/17] COPY config/check_repository.sh /                                                                                                                                      0.0s
 => [wazuh/wazuh-manager:4.6.0  5/17] RUN chmod 775 /check_repository.sh                                                                                                                                     0.5s
 => [wazuh/wazuh-manager:4.6.0  6/17] RUN source /check_repository.sh                                                                                                                                        2.4s
 => [wazuh/wazuh-manager:4.6.0  7/17] RUN apt-get update &&     apt-get install wazuh-manager=4.6.0-1                                                                                                      107.5s
 => [wazuh/wazuh-dashboard:4.6.0 builder  6/17] COPY config/config.sh .                                                                                                                                      0.1s
 => [wazuh/wazuh-dashboard:4.6.0 builder  7/17] COPY config/config.yml /                                                                                                                                     0.1s
 => [wazuh/wazuh-dashboard:4.6.0 builder  8/17] RUN bash config.sh                                                                                                                                           4.4s
 => [wazuh/wazuh-dashboard:4.6.0 builder  9/17] COPY config/install_wazuh_app.sh /                                                                                                                           0.1s
 => [wazuh/wazuh-dashboard:4.6.0 builder 10/17] RUN chmod 775 /install_wazuh_app.sh                                                                                                                          0.4s
 => [wazuh/wazuh-dashboard:4.6.0 builder 11/17] RUN bash /install_wazuh_app.sh                                                                                                                              18.5s
 => [wazuh/wazuh-dashboard:4.6.0 builder 12/17] COPY config/opensearch_dashboards.yml /usr/share/wazuh-dashboard/config/                                                                                     0.1s
 => [wazuh/wazuh-dashboard:4.6.0 builder 13/17] COPY config/wazuh.yml /usr/share/wazuh-dashboard/data/wazuh/config/                                                                                          0.1s
 => [wazuh/wazuh-dashboard:4.6.0 builder 14/17] RUN chown 101:101 /usr/share/wazuh-dashboard/config/opensearch_dashboards.yml && chmod 664 /usr/share/wazuh-dashboard/config/opensearch_dashboards.yml       0.3s
 => [wazuh/wazuh-dashboard:4.6.0 builder 15/17] RUN mkdir -p /usr/share/wazuh-dashboard/data/wazuh && chown -R 101:101 /usr/share/wazuh-dashboard/data/wazuh && chmod -R 775 /usr/share/wazuh-dashboard/dat  0.4s
 => [wazuh/wazuh-dashboard:4.6.0 builder 16/17] RUN mkdir -p /usr/share/wazuh-dashboard/data/wazuh/config && chown -R 101:101 /usr/share/wazuh-dashboard/data/wazuh/config && chmod -R 775 /usr/share/wazuh  0.3s
 => [wazuh/wazuh-dashboard:4.6.0 builder 17/17] RUN mkdir -p /usr/share/wazuh-dashboard/data/wazuh/logs && chown -R 101:101 /usr/share/wazuh-dashboard/data/wazuh/logs && chmod -R 775 /usr/share/wazuh-das  0.3s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1 10/13] COPY --from=builder --chown=1000:1000 /usr/share/wazuh-dashboard /usr/share/wazuh-dashboard                                                                 24.0s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1 11/13] RUN mkdir -p /usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom                                                                                   0.6s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1 12/13] RUN chown 1000:1000 /usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom                                                                            0.4s
 => [wazuh/wazuh-dashboard:4.6.0 stage-1 13/13] WORKDIR /usr/share/wazuh-dashboard                                                                                                                           0.1s
 => [wazuh/wazuh-dashboard:4.6.0] exporting to image                                                                                                                                                        12.4s
 => => exporting layers                                                                                                                                                                                     12.4s
 => => writing image sha256:fa35e95f2af41ed4e35ef63efdd801eea6205d19668f8238790173671884b793                                                                                                                 0.0s
 => => naming to docker.io/wazuh/wazuh-dashboard:4.6.0                                                                                                                                                       0.0s
 => [wazuh/wazuh-manager:4.6.0  8/17] RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-oss-7.10.2-amd64.deb &&    dpkg -i filebeat-oss-7.10.2-amd64.deb && rm -f filebeat-oss-  4.1s
 => [wazuh/wazuh-manager:4.6.0  9/17] RUN curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/v2.2.0.3/s6-overlay-amd64.tar.gz     -o /tmp/s6-overlay-amd64.tar.gz &&    2.4s
 => [wazuh/wazuh-manager:4.6.0 10/17] COPY config/etc/ /etc/                                                                                                                                                 0.2s
 => [wazuh/wazuh-manager:4.6.0 11/17] COPY --chown=root:wazuh config/create_user.py /var/ossec/framework/scripts/create_user.py                                                                              0.1s
 => [wazuh/wazuh-manager:4.6.0 12/17] COPY config/filebeat.yml /etc/filebeat/                                                                                                                                0.0s
 => [wazuh/wazuh-manager:4.6.0 13/17] RUN chmod go-w /etc/filebeat/filebeat.yml                                                                                                                              0.3s
 => [wazuh/wazuh-manager:4.6.0 14/17] ADD https://raw.githubusercontent.com/wazuh/wazuh/4.6.0/extensions/elasticsearch/7.x/wazuh-template.json /etc/filebeat                                                 0.0s
 => [wazuh/wazuh-manager:4.6.0 15/17] RUN chmod go-w /etc/filebeat/wazuh-template.json                                                                                                                       0.3s
 => [wazuh/wazuh-manager:4.6.0 16/17] COPY config/permanent_data.env config/permanent_data.sh /                                                                                                              0.1s
 => [wazuh/wazuh-manager:4.6.0 17/17] RUN chmod 755 /permanent_data.sh &&     sync && /permanent_data.sh &&     sync && rm /permanent_data.sh                                                                0.6s
 => [wazuh/wazuh-manager:4.6.0] exporting to image                                                                                                                                                           5.5s
 => => exporting layers                                                                                                                                                                                      5.5s
 => => writing image sha256:e6805aff8a5ee6ecd0337ed92185fb55cfb8c4480adcb1d298a933038422ae48                                                                                                                 0.0s
 => => naming to docker.io/wazuh/wazuh-manager:4.6.0                                                                                                                                                         0.0s
 => [wazuh/wazuh-indexer:4.6.0 stage-1  9/14] COPY --from=builder --chown=1000:1000 /debian/wazuh-indexer/usr/share/wazuh-indexer /usr/share/wazuh-indexer                                                   4.6s
 => [wazuh/wazuh-indexer:4.6.0 stage-1 10/14] COPY --from=builder --chown=0:0 /debian/wazuh-indexer/usr/lib/systemd /usr/lib/systemd                                                                         0.1s
 => [wazuh/wazuh-indexer:4.6.0 stage-1 11/14] COPY --from=builder --chown=0:0 /debian/wazuh-indexer/usr/lib/sysctl.d /usr/lib/sysctl.d                                                                       0.1s
 => [wazuh/wazuh-indexer:4.6.0 stage-1 12/14] COPY --from=builder --chown=0:0 /debian/wazuh-indexer/usr/lib/tmpfiles.d /usr/lib/tmpfiles.d                                                                   0.1s
 => [wazuh/wazuh-indexer:4.6.0 stage-1 13/14] RUN chown -R 1000:1000 /usr/share/wazuh-indexer                                                                                                               11.1s
 => [wazuh/wazuh-indexer:4.6.0 stage-1 14/14] RUN mkdir -p /var/lib/wazuh-indexer && chown 1000:1000 /var/lib/wazuh-indexer &&     mkdir -p /usr/share/wazuh-indexer/logs && chown 1000:1000 /usr/share/waz  0.6s
 => [wazuh/wazuh-indexer:4.6.0] exporting to image                                                                                                                                                           6.0s
 => => exporting layers                                                                                                                                                                                      6.0s
 => => writing image sha256:c43db073d24c021310292ec7fd29d78d33a8f190e7903d53ef7cb2636fee2ce6                                                                                                                 0.0s
 => => naming to docker.io/wazuh/wazuh-indexer:4.6.0
```
</details>


<details>
<summary>Single node</summary>

```console

[root@centos7-1 wazuh-docker]# cd single-node/
[root@centos7-1 single-node]# docker-compose -f generate-indexer-certs.yml run --rm generator
[+] Running 1/0
 ⠿ Network single-node_default  Created                                                                                                                                                                      0.0s
[+] Running 5/5
 ⠿ generator Pulled                                                                                                                                                                                          7.8s
   ⠿ edaedc954fb5 Already exists                                                                                                                                                                             0.0s
   ⠿ 573f4d11a520 Pull complete                                                                                                                                                                              5.4s
   ⠿ 8f200922197d Pull complete                                                                                                                                                                              5.5s
   ⠿ 55a86de68c5c Pull complete                                                                                                                                                                              5.5s
The tool to create the certificates exists in the in Packages bucket
04/10/2023 13:23:04 INFO: Admin certificates created.
04/10/2023 13:23:04 INFO: Wazuh indexer certificates created.
04/10/2023 13:23:04 INFO: Wazuh server certificates created.
04/10/2023 13:23:04 INFO: Wazuh dashboard certificates created.
Moving created certificates to the destination directory
Changing certificate permissions
Setting UID indexer and dashboard
Setting UID for wazuh manager and worker
[root@centos7-1 single-node]# docker-compose up -d
[+] Running 17/17
 ⠿ Volume "single-node_wazuh_var_multigroups"    Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_active_response"    Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_queue"              Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_filebeat_etc"             Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_logs"               Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_filebeat_var"             Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh-indexer-data"       Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_etc"                Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_api_configuration"  Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh-dashboard-custom"   Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_agentless"          Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh-dashboard-config"   Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_wodles"             Created                                                                                                                                                     0.0s
 ⠿ Volume "single-node_wazuh_integrations"       Created                                                                                                                                                     0.0s
 ⠿ Container single-node-wazuh.indexer-1         Started                                                                                                                                                     0.4s
 ⠿ Container single-node-wazuh.manager-1         Started                                                                                                                                                     0.5s
 ⠿ Container single-node-wazuh.dashboard-1       Started                                                                                                                                                     0.7s
[root@centos7-1 single-node]# docker ps
CONTAINER ID   IMAGE                         COMMAND                  CREATED         STATUS         PORTS                                                                                                                                                           NAMES
6451e90e32df   wazuh/wazuh-dashboard:4.6.0   "/entrypoint.sh"         3 seconds ago   Up 2 seconds   443/tcp, 0.0.0.0:443->5601/tcp, :::443->5601/tcp                                                                                                                single-node-wazuh.dashboard-1
43ef97906f08   wazuh/wazuh-manager:4.6.0     "/init"                  3 seconds ago   Up 2 seconds   0.0.0.0:1514-1515->1514-1515/tcp, :::1514-1515->1514-1515/tcp, 0.0.0.0:514->514/udp, :::514->514/udp, 0.0.0.0:55000->55000/tcp, :::55000->55000/tcp, 1516/tcp   single-node-wazuh.manager-1
ea8462df8a54   wazuh/wazuh-indexer:4.6.0     "/entrypoint.sh open…"   3 seconds ago   Up 2 seconds   0.0.0.0:9200->9200/tcp, :::9200->9200/tcp                                                                                                                       single-node-wazuh.indexer-1
[root@centos7-1 single-node]# docker exec -it single-node-wazuh.indexer-1 bash
wazuh-indexer@wazuh:~$ ls -la
total 296
drwx------. 1 wazuh-indexer wazuh-indexer     78 Oct  4 13:23 .
drwxr-xr-x. 1 root          root              27 Oct  4 13:16 ..
drwxrwxr-x. 3 wazuh-indexer wazuh-indexer     17 Oct  4 13:23 .cache
-rw-r-----. 1 wazuh-indexer wazuh-indexer  11358 Jun  2 18:00 LICENSE.txt
-rw-r-----. 1 wazuh-indexer wazuh-indexer 232360 Jun  2 18:00 NOTICE.txt
-rw-r-----. 1 wazuh-indexer wazuh-indexer      6 Sep 22 21:20 VERSION
drwxr-x---. 1 wazuh-indexer wazuh-indexer   4096 Sep 22 21:20 bin
drwxr-x---. 1 wazuh-indexer wazuh-indexer     56 Oct  4 13:23 certs
drwxrwxr-x. 2 wazuh-indexer wazuh-indexer      6 Oct  4 13:23 extensions
drwxr-x---. 1 wazuh-indexer wazuh-indexer    121 Jun  2 18:00 jdk
-rw-------. 1 wazuh-indexer wazuh-indexer   2701 Oct  4 13:19 jvm.options
drwxr-x---. 1 wazuh-indexer wazuh-indexer      6 Sep 22 21:20 jvm.options.d
drwxr-x---. 1 wazuh-indexer wazuh-indexer   4096 Jun  2 18:00 lib
-rw-r-----. 1 wazuh-indexer wazuh-indexer  14808 Sep 22 21:20 log4j2.properties
drwxr-xr-x. 2 wazuh-indexer wazuh-indexer      6 Oct  4 13:20 logs
drwxr-x---. 1 wazuh-indexer wazuh-indexer   4096 Jun  2 18:00 modules
drwxr-x---. 1 wazuh-indexer wazuh-indexer     31 Sep 22 21:20 opensearch-notifications
drwxr-x---. 1 wazuh-indexer wazuh-indexer     36 Sep 22 21:20 opensearch-notifications-core
drwxr-x---. 1 wazuh-indexer wazuh-indexer     31 Sep 22 21:20 opensearch-observability
drwxr-x---. 1 wazuh-indexer wazuh-indexer   4096 Sep 22 21:20 opensearch-performance-analyzer
drwxr-x---. 1 wazuh-indexer wazuh-indexer     35 Sep 22 21:20 opensearch-reports-scheduler
drwxr-x---. 1 wazuh-indexer wazuh-indexer   4096 Sep 22 21:20 opensearch-security
-rw-rw----. 1 wazuh-indexer wazuh-indexer    196 Oct  4 13:23 opensearch.keystore
-rw-r--r--. 1 root          root            1939 Oct  4 13:15 opensearch.yml
drwxr-x---. 1 wazuh-indexer wazuh-indexer     42 Jun  3 06:58 performance-analyzer-rca
drwxr-x---. 1 wazuh-indexer wazuh-indexer   4096 Jun  3 06:58 plugins
wazuh-indexer@wazuh:~$ ls -la modules/
total 28
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 .
drwx------. 1 wazuh-indexer wazuh-indexer   78 Oct  4 13:23 ..
drwxr-x---. 1 wazuh-indexer wazuh-indexer   84 Jun  2 18:00 aggs-matrix-stats
drwxr-x---. 1 wazuh-indexer wazuh-indexer   75 Jun  2 18:00 analysis-common
drwxr-x---. 1 wazuh-indexer wazuh-indexer   63 Jun  2 18:00 geo
drwxr-x---. 1 wazuh-indexer wazuh-indexer  192 Jun  2 18:00 ingest-common
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 ingest-geoip
drwxr-x---. 1 wazuh-indexer wazuh-indexer   77 Jun  2 18:00 ingest-user-agent
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 lang-expression
drwxr-x---. 1 wazuh-indexer wazuh-indexer  137 Jun  2 18:00 lang-mustache
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 lang-painless
drwxr-x---. 1 wazuh-indexer wazuh-indexer   80 Jun  2 18:00 mapper-extras
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 opensearch-dashboards
drwxr-x---. 1 wazuh-indexer wazuh-indexer   78 Jun  2 18:00 parent-join
drwxr-x---. 1 wazuh-indexer wazuh-indexer   77 Jun  2 18:00 percolator
drwxr-x---. 1 wazuh-indexer wazuh-indexer   76 Jun  2 18:00 rank-eval
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 reindex
drwxr-x---. 1 wazuh-indexer wazuh-indexer  104 Jun  2 18:00 repository-url
drwxr-x---. 1 wazuh-indexer wazuh-indexer   82 Jun  2 18:00 search-pipeline-common
drwxr-x---. 1 wazuh-indexer wazuh-indexer   97 Sep 22 21:25 systemd
drwxr-x---. 1 wazuh-indexer wazuh-indexer 4096 Jun  2 18:00 transport-netty4
```
</details>

![Screenshot_20231004_102447](https://github.com/wazuh/wazuh-docker/assets/64099752/53e76369-de37-4122-90cc-c6790622ca53)
