### PR TITLE
Changed validation order for wazuh branch

### DIFF
--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -44,10 +44,10 @@ build() {
             clean 1
         fi
     else
-        if curl --output /dev/null --silent --head --fail "https://github.com/wazuh/wazuh/tree/${FILEBEAT_TEMPLATE_BRANCH}"; then
-            FILEBEAT_TEMPLATE_BRANCH="${FILEBEAT_TEMPLATE_BRANCH}"
-        elif curl --output /dev/null --silent --head --fail "https://github.com/wazuh/wazuh/tree/v${FILEBEAT_TEMPLATE_BRANCH}"; then
+        if curl --output /dev/null --silent --head --fail "https://github.com/wazuh/wazuh/tree/v${FILEBEAT_TEMPLATE_BRANCH}"; then
             FILEBEAT_TEMPLATE_BRANCH="v${FILEBEAT_TEMPLATE_BRANCH}"
+        elif curl --output /dev/null --silent --head --fail "https://github.com/wazuh/wazuh/tree/${FILEBEAT_TEMPLATE_BRANCH}"; then
+            FILEBEAT_TEMPLATE_BRANCH="${FILEBEAT_TEMPLATE_BRANCH}"
         else
             WAZUH_MASTER_VERSION="$(curl -s https://raw.githubusercontent.com/wazuh/wazuh/master/src/VERSION | sed -e 's/v//g')"
             if [ "${FILEBEAT_TEMPLATE_BRANCH}" == "${WAZUH_MASTER_VERSION}" ]; then


### PR DESCRIPTION
closes https://github.com/wazuh/wazuh-docker/issues/1016

tests:

<details>
<summary>build-docker-images/build-images.sh -v 4.6.0</summary>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-docker$ build-docker-images/build-images.sh -v 4.6.0
+ WAZUH_IMAGE_VERSION=4.6.0
+ WAZUH_TAG_REVISION=1
+ WAZUH_DEV_STAGE=
+ FILEBEAT_MODULE_VERSION=0.2
+ trap ctrl_c INT
+ main -v 4.6.0
+ '[' -n -v ']'
+ case "${1}" in
+ '[' -n 4.6.0 ']'
+ WAZUH_IMAGE_VERSION=4.6.0
+ shift 2
+ '[' -n '' ']'
+ build
++ echo 4.6.0
++ sed -e 's/\.//g'
+ WAZUH_VERSION=460
+ FILEBEAT_TEMPLATE_BRANCH=4.6.0
+ WAZUH_FILEBEAT_MODULE=wazuh-filebeat-0.2.tar.gz
+ WAZUH_UI_REVISION=1
+ '[' '' ']'
+ curl --output /dev/null --silent --head --fail https://github.com/wazuh/wazuh/tree/v4.6.0
+ curl --output /dev/null --silent --head --fail https://github.com/wazuh/wazuh/tree/4.6.0
+ FILEBEAT_TEMPLATE_BRANCH=4.6.0
+ echo WAZUH_VERSION=4.6.0
+ echo WAZUH_IMAGE_VERSION=4.6.0
+ echo WAZUH_TAG_REVISION=1
+ echo FILEBEAT_TEMPLATE_BRANCH=4.6.0
+ echo WAZUH_FILEBEAT_MODULE=wazuh-filebeat-0.2.tar.gz
+ echo WAZUH_UI_REVISION=1
+ docker-compose -f build-docker-images/build-images.yml --env-file .env build --no-cache
...
```
</details>

<details>
<summary>build-docker-images/build-images.sh -v 4.6.0 -d alpha1</summary>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-docker$ build-docker-images/build-images.sh -v 4.6.0 -d alpha1
+ WAZUH_IMAGE_VERSION=4.6.0
+ WAZUH_TAG_REVISION=1
+ WAZUH_DEV_STAGE=
+ FILEBEAT_MODULE_VERSION=0.2
+ trap ctrl_c INT
+ main -v 4.6.0 -d alpha1
+ '[' -n -v ']'
+ case "${1}" in
+ '[' -n 4.6.0 ']'
+ WAZUH_IMAGE_VERSION=4.6.0
+ shift 2
+ '[' -n -d ']'
+ case "${1}" in
+ '[' -n alpha1 ']'
+ WAZUH_DEV_STAGE=alpha1
+ shift 2
+ '[' -n '' ']'
+ build
++ echo 4.6.0
++ sed -e 's/\.//g'
+ WAZUH_VERSION=460
+ FILEBEAT_TEMPLATE_BRANCH=4.6.0
+ WAZUH_FILEBEAT_MODULE=wazuh-filebeat-0.2.tar.gz
+ WAZUH_UI_REVISION=1
+ '[' alpha1 ']'
+ FILEBEAT_TEMPLATE_BRANCH=v4.6.0-alpha1
+ curl --output /dev/null --silent --head --fail https://github.com/wazuh/wazuh/tree/v4.6.0-alpha1
+ echo WAZUH_VERSION=4.6.0
+ echo WAZUH_IMAGE_VERSION=4.6.0
+ echo WAZUH_TAG_REVISION=1
+ echo FILEBEAT_TEMPLATE_BRANCH=v4.6.0-alpha1
+ echo WAZUH_FILEBEAT_MODULE=wazuh-filebeat-0.2.tar.gz
+ echo WAZUH_UI_REVISION=1
+ docker-compose -f build-docker-images/build-images.yml --env-file .env build --no-cache
```
</details>