### PR TITLE
Fix multigroups folder with wrong permissions

### DIFF
--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -49,6 +49,10 @@ RUN chmod 755 /permanent_data.sh && \
     sync && /permanent_data.sh && \
     sync && rm /permanent_data.sh
 
+RUN mkdir -p /var/ossec/var/multigroups && \
+    chown root:wazuh /var/ossec/var/multigroups && \
+    chmod 770 /var/ossec/var/multigroups
+
 # Services ports
 EXPOSE 55000/tcp 1514/tcp 1515/tcp 514/udp 1516/tcp
 


### PR DESCRIPTION
This is a fix for #745

A folder permission error prevented from merging multiple `agent.conf` files when the agent was belonging to multiple groups.

This is simply an implementation of [this answer](https://github.com/wazuh/wazuh-docker/issues/745#issuecomment-1326822550).

It was tested on the latest release (v4.5.3), where the issue still exists.

It's my first pull request, be gentle with me 😁