### PR TITLE
Updated Filebeat module version to 0.3

### DIFF
--- a/build-docker-images/README.md
+++ b/build-docker-images/README.md
@@ -24,7 +24,7 @@ $ build-docker-images/build-images.sh -h
 Usage: build-docker-images/build-images.sh [OPTIONS]
 
     -d, --dev <ref>              [Optional] Set the development stage you want to build, example rc1 or beta1, not used by default.
-    -f, --filebeat-module <ref>  [Optional] Set Filebeat module version. By default 0.2.
+    -f, --filebeat-module <ref>  [Optional] Set Filebeat module version. By default 0.3.
     -r, --revision <rev>         [Optional] Package revision. By default 1
     -v, --version <ver>          [Optional] Set the Wazuh version should be builded. By default, 4.7.0.
     -h, --help                   Show this help.

--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -15,7 +15,7 @@ IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
 WAZUH_IMAGE_VERSION="4.7.0"
 WAZUH_TAG_REVISION="1"
 WAZUH_DEV_STAGE=""
-FILEBEAT_MODULE_VERSION="0.2"
+FILEBEAT_MODULE_VERSION="0.3"
 
 # -----------------------------------------------------------------------------
 

--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 
 RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb &&\
     dpkg -i ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb && rm -f ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb && \
-    curl -s https://packages.wazuh.com/4.x/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
+    curl -s https://packages-dev.wazuh.com/pre-release/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
 
 ARG S6_VERSION="v2.2.0.3"
 RUN curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz \

--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && \
 
 RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb &&\
     dpkg -i ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb && rm -f ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb && \
-    curl -s https://packages-dev.wazuh.com/pre-release/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
+    curl -s https://packages.wazuh.com/4.x/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
 
 ARG S6_VERSION="v2.2.0.3"
 RUN curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz \


### PR DESCRIPTION
closes https://github.com/wazuh/wazuh-docker/issues/1116

Updated Filebeat module version to 0.3

### Docker build

```console
Processing triggers for libc-bin (2.31-0ubuntu9.12) ...
Processing triggers for ca-certificates (20230311ubuntu0.20.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Removing intermediate container fb8678ed3bcb
 ---> 83505aaba314
Step 10/26 : COPY config/check_repository.sh /
 ---> 59ac71aa6efd
Step 11/26 : RUN chmod 775 /check_repository.sh
 ---> Running in 51afb04d5753
Removing intermediate container 51afb04d5753
 ---> 7e2b41d57b2d
Step 12/26 : RUN source /check_repository.sh
 ---> Running in 7db77ff41579
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.awqUeJKxrh/gpg.1.sh --fetch-keys https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH
gpg: requesting key from 'https://packages-dev.wazuh.com/key/GPG-KEY-WAZUH'
gpg: key 96B3EE5F29111145: public key "Wazuh.com (Wazuh Signing Key) <support@wazuh.com>" imported
gpg: Total number processed: 1
gpg:               imported: 1
deb https://packages-dev.wazuh.com/pre-release/apt/ unstable main
Removing intermediate container 7db77ff41579
 ---> b986923ef4ca
Step 13/26 : RUN apt-get update &&     apt-get install wazuh-manager=${WAZUH_VERSION}-${WAZUH_TAG_REVISION}
 ---> Running in 5970ec257e26
Hit:1 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu focal InRelease
Hit:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
Get:4 https://packages-dev.wazuh.com/pre-release/apt unstable InRelease [17.3 kB]
Hit:5 http://archive.ubuntu.com/ubuntu focal-backports InRelease
Get:6 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 Packages [39.3 kB]
Fetched 56.6 kB in 2s (23.1 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Suggested packages:
  expect
The following NEW packages will be installed:
  wazuh-manager
0 upgraded, 1 newly installed, 0 to remove and 2 not upgraded.
Need to get 171 MB of archives.
After this operation, 629 MB of additional disk space will be used.
Get:1 https://packages-dev.wazuh.com/pre-release/apt unstable/main amd64 wazuh-manager amd64 4.7.0-1 [171 MB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 171 MB in 22s (7618 kB/s)
Selecting previously unselected package wazuh-manager.
(Reading database ... 5723 files and directories currently installed.)
Preparing to unpack .../wazuh-manager_4.7.0-1_amd64.deb ...
Unpacking wazuh-manager (4.7.0-1) ...
Setting up wazuh-manager (4.7.0-1) ...
Removing intermediate container 5970ec257e26
 ---> 677bfabcf23b
Step 14/26 : RUN curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb &&    dpkg -i ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb && rm -f ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-amd64.deb &&     curl -s https://packages-dev.wazuh.com/pre-release/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module
 ---> Running in cdb0271b2e78
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21.0M  100 21.0M    0     0  4003k      0  0:00:05  0:00:05 --:--:-- 5192k
Selecting previously unselected package filebeat.
(Reading database ... 27011 files and directories currently installed.)
Preparing to unpack filebeat-oss-7.10.2-amd64.deb ...
Unpacking filebeat (7.10.2) ...
Setting up filebeat (7.10.2) ...
wazuh/
wazuh/archives/
wazuh/archives/ingest/
wazuh/archives/ingest/pipeline.json
wazuh/archives/config/
wazuh/archives/config/archives.yml
wazuh/archives/manifest.yml
wazuh/alerts/
wazuh/alerts/ingest/
wazuh/alerts/ingest/pipeline.json
wazuh/alerts/config/
wazuh/alerts/config/alerts.yml
wazuh/alerts/manifest.yml
wazuh/module.yml
Removing intermediate container cdb0271b2e78
 ---> 26660584d295
Step 15/26 : ARG S6_VERSION="v2.2.0.3"
 ---> Running in 165175b292e6
Removing intermediate container 165175b292e6
 ---> fc7878634825
Step 16/26 : RUN curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz     -o /tmp/s6-overlay-amd64.tar.gz &&     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" &&     tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin &&     rm  /tmp/s6-overlay-amd64.tar.gz
 ---> Running in 1a98726fad6c
Removing intermediate container 1a98726fad6c
 ---> 831ce4f23221
Step 17/26 : COPY config/etc/ /etc/
 ---> 5a4b568e3d34
Step 18/26 : COPY --chown=root:wazuh config/create_user.py /var/ossec/framework/scripts/create_user.py
 ---> f558bce2f729
Step 19/26 : COPY config/filebeat.yml /etc/filebeat/
 ---> a4e1db530a42
Step 20/26 : RUN chmod go-w /etc/filebeat/filebeat.yml
 ---> Running in 461405b8feff
Removing intermediate container 461405b8feff
 ---> d00659029611
Step 21/26 : ADD https://raw.githubusercontent.com/wazuh/wazuh/$FILEBEAT_TEMPLATE_BRANCH/extensions/elasticsearch/7.x/wazuh-template.json /etc/filebeat
Downloading  62.78kB
 ---> b45f7843db61
Step 22/26 : RUN chmod go-w /etc/filebeat/wazuh-template.json
 ---> Running in 45a89c016216
Removing intermediate container 45a89c016216
 ---> e98f2a959624
Step 23/26 : COPY config/permanent_data.env config/permanent_data.sh /
 ---> db01c2b8e9ab
Step 24/26 : RUN chmod 755 /permanent_data.sh &&     sync && /permanent_data.sh &&     sync && rm /permanent_data.sh
 ---> Running in 1cf7131f057b
Removing intermediate container 1cf7131f057b
 ---> c20a9430c434
Step 25/26 : EXPOSE 55000/tcp 1514/tcp 1515/tcp 514/udp 1516/tcp
 ---> Running in 5a1b1b479dee
Removing intermediate container 5a1b1b479dee
 ---> 19dd2ce94ca8
Step 26/26 : ENTRYPOINT [ "/init" ]
 ---> Running in 997c05fd75ca
Removing intermediate container 997c05fd75ca
 ---> b5079c9cebf2
Successfully built b5079c9cebf2
Successfully tagged wazuh/wazuh-manager:4.7.0

```

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-docker$ docker exec -it manager cat /usr/share/filebeat/module/wazuh/alerts/ingest/pipeline.json
{
  "description": "Wazuh alerts pipeline",
  "processors": [
    { "json" : { "field" : "message", "add_to_root": true } },
    {
      "set": {
        "field": "data.aws.region",
        "value": "{{data.aws.awsRegion}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "set": {
        "field": "data.aws.accountId",
        "value": "{{data.aws.aws_account_id}}",
        "override": false,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.srcip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.win.eventdata.ipAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.sourceIPAddress",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.client_ip",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.aws.service.action.networkConnectionAction.remoteIpDetails.ipAddressV4",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.gcp.jsonPayload.sourceIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "geoip": {
        "field": "data.office365.ClientIP",
        "target_field": "GeoLocation",
        "properties": ["city_name", "country_name", "region_name", "location"],
        "ignore_missing": true,
        "ignore_failure": true
      }
    },
    {
      "date": {
        "field": "timestamp",
        "target_field": "@timestamp",
        "formats": ["ISO8601"],
        "ignore_failure": false
      }
    },
    {
      "date_index_name": {
        "field": "timestamp",
        "date_rounding": "d",
        "index_name_prefix": "{{fields.index_prefix}}",
        "index_name_format": "yyyy.MM.dd",
        "ignore_failure": false
      }
    },

    { "remove": { "field": "message", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "ecs", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "beat", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "input_type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "tags", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "count", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "@version", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "log", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "offset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "type", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "host", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fields", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "event", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "fileset", "ignore_missing": true, "ignore_failure": true } },
    { "remove": { "field": "service", "ignore_missing": true, "ignore_failure": true } }
  ],
  "on_failure" : [{
    "drop" : { }
  }]
}
```