### PR TITLE
Adapted docker build to multiple Wazuh Dashboards plugins

### DIFF
--- a/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
+++ b/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
@@ -1,8 +1,7 @@
 ## variables
 WAZUH_APP=https://packages.wazuh.com/4.x/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
-WAZUH_APP=https://packages.wazuh.com/4.x/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
 WAZUH_CHECK_UPDATES=https://packages.wazuh.com/4.x/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
-WAZUH_CORE=https://packages-dev.wazuh.com/staging/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+WAZUH_CORE=https://packages.wazuh.com/4.x/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
 WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
 MAJOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f1)
 MID_BUILD=$(echo $WAZUH_VERSION | cut -d. -f2)
@@ -14,12 +13,18 @@ MINOR_CURRENT=$(echo $WAZUH_CURRENT_VERSION | cut -d. -f3)
 ## check version to use the correct repository
 if [ "$MAJOR_BUILD" -gt "$MAJOR_CURRENT" ]; then
   WAZUH_APP=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+  WAZUH_CHECK_UPDATES=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+  WAZUH_CORE=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
 elif [ "$MAJOR_BUILD" -eq "$MAJOR_CURRENT" ]; then
   if [ "$MID_BUILD" -gt "$MID_CURRENT" ]; then
     WAZUH_APP=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+      WAZUH_CHECK_UPDATES=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+    WAZUH_CORE=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
   elif [ "$MID_BUILD" -eq "$MID_CURRENT" ]; then
     if [ "$MINOR_BUILD" -gt "$MINOR_CURRENT" ]; then
       WAZUH_APP=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+      WAZUH_CHECK_UPDATES=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+      WAZUH_CORE=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
     fi
   fi
 fi

--- a/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
+++ b/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
@@ -18,7 +18,7 @@ if [ "$MAJOR_BUILD" -gt "$MAJOR_CURRENT" ]; then
 elif [ "$MAJOR_BUILD" -eq "$MAJOR_CURRENT" ]; then
   if [ "$MID_BUILD" -gt "$MID_CURRENT" ]; then
     WAZUH_APP=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
-      WAZUH_CHECK_UPDATES=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+    WAZUH_CHECK_UPDATES=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
     WAZUH_CORE=https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
   elif [ "$MID_BUILD" -eq "$MID_CURRENT" ]; then
     if [ "$MINOR_BUILD" -gt "$MINOR_CURRENT" ]; then

--- a/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
+++ b/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
@@ -1,5 +1,8 @@
 ## variables
 WAZUH_APP=https://packages.wazuh.com/4.x/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+WAZUH_APP=https://packages.wazuh.com/4.x/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+WAZUH_CHECK_UPDATES=https://packages.wazuh.com/4.x/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
+WAZUH_CORE=https://packages-dev.wazuh.com/staging/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
 WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
 MAJOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f1)
 MID_BUILD=$(echo $WAZUH_VERSION | cut -d. -f2)
@@ -23,3 +26,5 @@ fi
 
 # Install Wazuh App
 $INSTALL_DIR/bin/opensearch-dashboards-plugin install $WAZUH_APP --allow-root
+$INSTALL_DIR/bin/opensearch-dashboards-plugin install $WAZUH_CHECK_UPDATES --allow-root
+$INSTALL_DIR/bin/opensearch-dashboards-plugin install $WAZUH_CORE --allow-root


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-docker/issues/1099

The aim of this PR is to adapt the Docker build to multiple Wazuh Dashboard plugins. This PR is related to https://github.com/wazuh/internal-devel-requests/issues/464.

## Testing

The Wazuh stack was successfully deployed:

![Image](https://github.com/wazuh/wazuh-docker/assets/72193239/0a9b663c-7d28-442f-a0ec-47a4deaa7570)

<details><summary>Show log</summary>

```console
$ build-docker-images/build-images.sh
Building wazuh.manager
Step 1/27 : FROM ubuntu:jammy
 ---> e4c58958181a
Step 2/27 : RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 ---> Running in 15b77971c8d2
Removing intermediate container 15b77971c8d2
 ---> 68ebf2afdd3b
Step 3/27 : ARG WAZUH_VERSION
 ---> Running in a23005cb32f1
Removing intermediate container a23005cb32f1
 ---> b47401da587d
Step 4/27 : ARG WAZUH_TAG_REVISION
 ---> Running in 991b3313b34b
Removing intermediate container 991b3313b34b
 ---> 7fc5dc803c98
Step 5/27 : ARG FILEBEAT_TEMPLATE_BRANCH
 ---> Running in 96e54e42984a
Removing intermediate container 96e54e42984a
 ---> af6b461136b7
Step 6/27 : ARG FILEBEAT_CHANNEL=filebeat-oss
 ---> Running in ed609e19c64f
Removing intermediate container ed609e19c64f
 ---> 80ea71a81fcb
Step 7/27 : ARG FILEBEAT_VERSION=7.10.2
 ---> Running in e4d19971949f
Removing intermediate container e4d19971949f
 ---> bf25cef29665
Step 8/27 : ARG WAZUH_FILEBEAT_MODULE
 ---> Running in cf9605a5d329
Removing intermediate container cf9605a5d329
 ---> 31f4299bf2a8
Step 9/27 : RUN apt-get update && apt install curl apt-transport-https lsb-release gnupg -y
 ---> Running in 8bbf6333618b
...
Step 1/39 : FROM ubuntu:jammy AS builder
 ---> e4c58958181a
Step 2/39 : ARG WAZUH_VERSION
 ---> Running in ea16afa9c8cf
Removing intermediate container ea16afa9c8cf
 ---> b65bfe41e7b5
Step 3/39 : ARG WAZUH_TAG_REVISION
 ---> Running in ef4b9d9f1116
Removing intermediate container ef4b9d9f1116
 ---> 7660ea4fa46f
Step 4/39 : ARG INSTALL_DIR=/usr/share/wazuh-dashboard
 ---> Running in 1eeb12a6ce71
Removing intermediate container 1eeb12a6ce71
 ---> ba424286620f
Step 5/39 : ARG WAZUH_UI_REVISION
 ---> Running in f8343a7db5a9
Removing intermediate container f8343a7db5a9
 ---> d3fef8ba8d82
Step 6/39 : RUN apt-get update && apt install curl libcap2-bin xz-utils -y
 ---> Running in 353efa548c16
Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:3 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [44.0 kB]
Get:4 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [1404 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Get:6 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1010 kB]
Get:7 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1203 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1277 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [1430 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1472 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [49.8 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [78.3 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [32.6 kB]
Fetched 28.3 MB in 2min 27s (193 kB/s)
Reading package lists...

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  ca-certificates libbrotli1 libcurl4 libldap-2.5-0 libldap-common
  libnghttp2-14 libpam-cap libpsl5 librtmp1 libsasl2-2 libsasl2-modules
  libsasl2-modules-db libssh-4 openssl publicsuffix
Suggested packages:
  libsasl2-modules-gssapi-mit | libsasl2-modules-gssapi-heimdal
  libsasl2-modules-ldap libsasl2-modules-otp libsasl2-modules-sql
The following NEW packages will be installed:
  ca-certificates curl libbrotli1 libcap2-bin libcurl4 libldap-2.5-0
  libldap-common libnghttp2-14 libpam-cap libpsl5 librtmp1 libsasl2-2
  libsasl2-modules libsasl2-modules-db libssh-4 openssl publicsuffix xz-utils
0 upgraded, 18 newly installed, 0 to remove and 11 not upgraded.
Need to get 3105 kB of archives.
After this operation, 7669 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 openssl amd64 3.0.2-0ubuntu1.12 [1182 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 ca-certificates all 20230311ubuntu0.22.04.1 [155 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcap2-bin amd64 1:2.44-1ubuntu0.22.04.1 [26.0 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libpam-cap amd64 1:2.44-1ubuntu0.22.04.1 [7928 B]
Get:5 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnghttp2-14 amd64 1.43.0-1build3 [76.3 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/main amd64 libpsl5 amd64 0.21.0-1.2build2 [58.4 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 publicsuffix all 20211207.1025-1 [129 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy/main amd64 xz-utils amd64 5.2.5-2ubuntu1 [84.8 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 libbrotli1 amd64 1.0.9-2build6 [315 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg2-3ubuntu1.2 [20.5 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-2 amd64 2.1.27+dfsg2-3ubuntu1.2 [53.8 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-2.5-0 amd64 2.5.16+dfsg-0ubuntu0.22.04.1 [183 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build4 [58.2 kB]
Get:14 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libssh-4 amd64 0.9.6-2ubuntu0.22.04.1 [185 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libcurl4 amd64 7.81.0-1ubuntu1.14 [290 kB]
Get:16 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 curl amd64 7.81.0-1ubuntu1.14 [194 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libldap-common all 2.5.16+dfsg-0ubuntu0.22.04.1 [15.8 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsasl2-modules amd64 2.1.27+dfsg2-3ubuntu1.2 [68.8 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 3105 kB in 46s (67.3 kB/s)
Selecting previously unselected package openssl.
(Reading database ... 4395 files and directories currently installed.)
Preparing to unpack .../00-openssl_3.0.2-0ubuntu1.12_amd64.deb ...
Unpacking openssl (3.0.2-0ubuntu1.12) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../01-ca-certificates_20230311ubuntu0.22.04.1_all.deb ...
Unpacking ca-certificates (20230311ubuntu0.22.04.1) ...
Selecting previously unselected package libcap2-bin.
Preparing to unpack .../02-libcap2-bin_1%3a2.44-1ubuntu0.22.04.1_amd64.deb ...
Unpacking libcap2-bin (1:2.44-1ubuntu0.22.04.1) ...
Selecting previously unselected package libpam-cap:amd64.
Preparing to unpack .../03-libpam-cap_1%3a2.44-1ubuntu0.22.04.1_amd64.deb ...
Unpacking libpam-cap:amd64 (1:2.44-1ubuntu0.22.04.1) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../04-libnghttp2-14_1.43.0-1build3_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.43.0-1build3) ...
Selecting previously unselected package libpsl5:amd64.
Preparing to unpack .../05-libpsl5_0.21.0-1.2build2_amd64.deb ...
Unpacking libpsl5:amd64 (0.21.0-1.2build2) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../06-publicsuffix_20211207.1025-1_all.deb ...
Unpacking publicsuffix (20211207.1025-1) ...
Selecting previously unselected package xz-utils.
Preparing to unpack .../07-xz-utils_5.2.5-2ubuntu1_amd64.deb ...
Unpacking xz-utils (5.2.5-2ubuntu1) ...
Selecting previously unselected package libbrotli1:amd64.
Preparing to unpack .../08-libbrotli1_1.0.9-2build6_amd64.deb ...
Unpacking libbrotli1:amd64 (1.0.9-2build6) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../09-libsasl2-modules-db_2.1.27+dfsg2-3ubuntu1.2_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../10-libsasl2-2_2.1.27+dfsg2-3ubuntu1.2_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Selecting previously unselected package libldap-2.5-0:amd64.
Preparing to unpack .../11-libldap-2.5-0_2.5.16+dfsg-0ubuntu0.22.04.1_amd64.deb ...
Unpacking libldap-2.5-0:amd64 (2.5.16+dfsg-0ubuntu0.22.04.1) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../12-librtmp1_2.4+20151223.gitfa8646d.1-2build4_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../13-libssh-4_0.9.6-2ubuntu0.22.04.1_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.6-2ubuntu0.22.04.1) ...
Selecting previously unselected package libcurl4:amd64.
Preparing to unpack .../14-libcurl4_7.81.0-1ubuntu1.14_amd64.deb ...
Unpacking libcurl4:amd64 (7.81.0-1ubuntu1.14) ...
Selecting previously unselected package curl.
Preparing to unpack .../15-curl_7.81.0-1ubuntu1.14_amd64.deb ...
Unpacking curl (7.81.0-1ubuntu1.14) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../16-libldap-common_2.5.16+dfsg-0ubuntu0.22.04.1_all.deb ...
Unpacking libldap-common (2.5.16+dfsg-0ubuntu0.22.04.1) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../17-libsasl2-modules_2.1.27+dfsg2-3ubuntu1.2_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up libpsl5:amd64 (0.21.0-1.2build2) ...
Setting up libbrotli1:amd64 (1.0.9-2build6) ...
Setting up libsasl2-modules:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up libnghttp2-14:amd64 (1.43.0-1build3) ...
Setting up libldap-common (2.5.16+dfsg-0ubuntu0.22.04.1) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up libcap2-bin (1:2.44-1ubuntu0.22.04.1) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build4) ...
Setting up xz-utils (5.2.5-2ubuntu1) ...
update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/lzma.1.gz because associated file /usr/share/man/man1/xz.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/unlzma.1.gz because associated file /usr/share/man/man1/unxz.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzcat.1.gz because associated file /usr/share/man/man1/xzcat.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzmore.1.gz because associated file /usr/share/man/man1/xzmore.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzless.1.gz because associated file /usr/share/man/man1/xzless.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzdiff.1.gz because associated file /usr/share/man/man1/xzdiff.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzcmp.1.gz because associated file /usr/share/man/man1/xzcmp.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzgrep.1.gz because associated file /usr/share/man/man1/xzgrep.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzegrep.1.gz because associated file /usr/share/man/man1/xzegrep.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzfgrep.1.gz because associated file /usr/share/man/man1/xzfgrep.1.gz (of link group lzma) doesn't exist
Setting up libsasl2-2:amd64 (2.1.27+dfsg2-3ubuntu1.2) ...
Setting up libssh-4:amd64 (0.9.6-2ubuntu0.22.04.1) ...
Setting up openssl (3.0.2-0ubuntu1.12) ...
Setting up libpam-cap:amd64 (1:2.44-1ubuntu0.22.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.34.0 /usr/local/share/perl/5.34.0 /usr/lib/x86_64-linux-gnu/perl5/5.34 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.34 /usr/share/perl/5.34 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up publicsuffix (20211207.1025-1) ...
Setting up libldap-2.5-0:amd64 (2.5.16+dfsg-0ubuntu0.22.04.1) ...
Setting up ca-certificates (20230311ubuntu0.22.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.34.0 /usr/local/share/perl/5.34.0 /usr/lib/x86_64-linux-gnu/perl5/5.34 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl-base /usr/lib/x86_64-linux-gnu/perl/5.34 /usr/share/perl/5.34 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Updating certificates in /etc/ssl/certs...
137 added, 0 removed; done.
Setting up libcurl4:amd64 (7.81.0-1ubuntu1.14) ...
Setting up curl (7.81.0-1ubuntu1.14) ...
Processing triggers for libc-bin (2.35-0ubuntu3.4) ...
Processing triggers for ca-certificates (20230311ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Removing intermediate container 353efa548c16
 ---> 75c9fe924e7a
Step 7/39 : RUN mkdir -p $INSTALL_DIR
 ---> Running in 0d1d5f65121c
Removing intermediate container 0d1d5f65121c
 ---> d783886b42a1
Step 8/39 : COPY config/dl_base.sh .
 ---> 6c9c77caf604
Step 9/39 : RUN bash dl_base.sh
 ---> Running in d46dcc2582a1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  153M  100  153M    0     0   563k      0  0:04:39  0:04:39 --:--:--  308k
Removing intermediate container d46dcc2582a1
 ---> 017398a7048f
Step 10/39 : COPY config/config.sh .
 ---> 80d012e13dfd
Step 11/39 : COPY config/config.yml /
 ---> bf8a2c0c611d
Step 12/39 : RUN bash config.sh
 ---> Running in d380a2c0b8ae
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 34120  100 34120    0     0  27447      0  0:00:01  0:00:01 --:--:-- 27449
Cert tool exists in Packages-dev bucket
16/11/2023 10:53:34 INFO: Admin certificates created.
16/11/2023 10:53:34 INFO: Wazuh dashboard certificates created.
Removing intermediate container d380a2c0b8ae
 ---> 7d0f9f3aa8b2
Step 13/39 : COPY config/install_wazuh_app.sh /
 ---> ae215bfa8d9a
Step 14/39 : RUN chmod 775 /install_wazuh_app.sh
 ---> Running in 0ad547c819a3
Removing intermediate container 0ad547c819a3
 ---> 954c7ab5cc7e
Step 15/39 : RUN bash /install_wazuh_app.sh
 ---> Running in 3460888f77e3
Attempting to transfer from https://packages-dev.wazuh.com/staging/ui/dashboard/wazuh-4.8.0-40800.zip
Transferring 34138886 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete
Attempting to transfer from https://packages-dev.wazuh.com/staging/ui/dashboard/wazuhCheckUpdates-4.8.0-40800.zip
Transferring 1864691 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete
Attempting to transfer from https://packages-dev.wazuh.com/staging/ui/dashboard/wazuhCore-4.8.0-40800.zip
Transferring 3199973 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete
Removing intermediate container 3460888f77e3
 ---> 95f6f61ded32
Step 16/39 : COPY config/opensearch_dashboards.yml $INSTALL_DIR/config/
 ---> c093015ad589
Step 17/39 : COPY config/wazuh.yml $INSTALL_DIR/data/wazuh/config/
 ---> 3e35d9923d4c
Step 18/39 : RUN chown 101:101 $INSTALL_DIR/config/opensearch_dashboards.yml && chmod 664 $INSTALL_DIR/config/opensearch_dashboards.yml
 ---> Running in 71e3e80ed1fb
Removing intermediate container 71e3e80ed1fb
 ---> 95a17ec4e9a6
Step 19/39 : RUN mkdir -p $INSTALL_DIR/data/wazuh && chown -R 101:101 $INSTALL_DIR/data/wazuh && chmod -R 775 $INSTALL_DIR/data/wazuh
 ---> Running in 508dc8aa8d23
Removing intermediate container 508dc8aa8d23
 ---> 0588f6b78ba0
Step 20/39 : RUN mkdir -p $INSTALL_DIR/data/wazuh/config && chown -R 101:101 $INSTALL_DIR/data/wazuh/config && chmod -R 775 $INSTALL_DIR/data/wazuh/config
 ---> Running in 10a53aa38d25
Removing intermediate container 10a53aa38d25
 ---> 4ea1bcd5a285
Step 21/39 : RUN mkdir -p $INSTALL_DIR/data/wazuh/logs && chown -R 101:101 $INSTALL_DIR/data/wazuh/logs && chmod -R 775 $INSTALL_DIR/data/wazuh/logs
 ---> Running in 66fb5c604f8f
Removing intermediate container 66fb5c604f8f
 ---> 8be66c8dbcf6

Step 22/39 : FROM ubuntu:jammy
 ---> e4c58958181a
Step 23/39 : ENV USER="wazuh-dashboard"     GROUP="wazuh-dashboard"     NAME="wazuh-dashboard"     INSTALL_DIR="/usr/share/wazuh-dashboard"
 ---> Running in 5d0468fa28a0
Removing intermediate container 5d0468fa28a0
 ---> 8c163d456b27
Step 24/39 : ENV PATTERN=""     CHECKS_PATTERN=""     CHECKS_TEMPLATE=""     CHECKS_API=""     CHECKS_SETUP=""     EXTENSIONS_PCI=""     EXTENSIONS_GDPR=""     EXTENSIONS_HIPAA=""     EXTENSIONS_NIST=""     EXTENSIONS_TSC=""     EXTENSIONS_AUDIT=""     EXTENSIONS_OSCAP=""     EXTENSIONS_CISCAT=""     EXTENSIONS_AWS=""     EXTENSIONS_GCP=""     EXTENSIONS_GITHUB=""    EXTENSIONS_OFFICE=""    EXTENSIONS_VIRUSTOTAL=""     EXTENSIONS_OSQUERY=""     EXTENSIONS_DOCKER=""     APP_TIMEOUT=""     API_SELECTOR=""     IP_SELECTOR=""     IP_IGNORE=""     WAZUH_MONITORING_ENABLED=""     WAZUH_MONITORING_FREQUENCY=""     WAZUH_MONITORING_SHARDS=""     WAZUH_MONITORING_REPLICAS=""
 ---> Running in 6400a3f527f0
Removing intermediate container 6400a3f527f0
 ---> f5f86021e762
Step 25/39 : RUN apt update && apt install -y libnss3-dev fonts-liberation libfontconfig1
 ---> Running in 4a67056a7f00

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:2 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
Get:3 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1203 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease [109 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/universe amd64 Packages [17.5 MB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 Packages [1792 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy/multiverse amd64 Packages [266 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/restricted amd64 Packages [164 kB]
Ign:10 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages
Get:11 http://archive.ubuntu.com/ubuntu jammy-updates/restricted amd64 Packages [1430 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/universe amd64 Packages [1277 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 Packages [1472 kB]
Get:14 http://security.ubuntu.com/ubuntu jammy-security/multiverse amd64 Packages [44.0 kB]
Get:15 http://archive.ubuntu.com/ubuntu jammy-updates/multiverse amd64 Packages [49.8 kB]
Get:16 http://security.ubuntu.com/ubuntu jammy-security/restricted amd64 Packages [1404 kB]
Get:17 http://archive.ubuntu.com/ubuntu jammy-backports/universe amd64 Packages [32.6 kB]
Get:18 http://archive.ubuntu.com/ubuntu jammy-backports/main amd64 Packages [78.3 kB]
Get:10 http://security.ubuntu.com/ubuntu jammy-security/universe amd64 Packages [1010 kB]
Fetched 28.3 MB in 45s (634 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
11 packages can be upgraded. Run 'apt list --upgradable' to see them.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  fontconfig-config libbrotli1 libexpat1 libfreetype6 libnspr4 libnspr4-dev
  libnss3 libpng16-16 libsqlite3-0 ucf
The following NEW packages will be installed:
  fontconfig-config fonts-liberation libbrotli1 libexpat1 libfontconfig1
  libfreetype6 libnspr4 libnspr4-dev libnss3 libnss3-dev libpng16-16
  libsqlite3-0 ucf
0 upgraded, 13 newly installed, 0 to remove and 11 not upgraded.
Need to get 4524 kB of archives.
After this operation, 13.9 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libexpat1 amd64 2.4.7-1ubuntu0.2 [91.0 kB]
Get:2 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libsqlite3-0 amd64 3.37.2-2ubuntu0.1 [641 kB]
Get:3 http://archive.ubuntu.com/ubuntu jammy/main amd64 ucf all 3.0043 [56.1 kB]
Get:4 http://archive.ubuntu.com/ubuntu jammy/main amd64 libpng16-16 amd64 1.6.37-3build5 [191 kB]
Get:5 http://archive.ubuntu.com/ubuntu jammy/main amd64 fonts-liberation all 1:1.07.4-11 [822 kB]
Get:6 http://archive.ubuntu.com/ubuntu jammy/main amd64 fontconfig-config all 2.13.1-4.2ubuntu5 [29.1 kB]
Get:7 http://archive.ubuntu.com/ubuntu jammy/main amd64 libbrotli1 amd64 1.0.9-2build6 [315 kB]
Get:8 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libfreetype6 amd64 2.11.1+dfsg-1ubuntu0.2 [389 kB]
Get:9 http://archive.ubuntu.com/ubuntu jammy/main amd64 libfontconfig1 amd64 2.13.1-4.2ubuntu5 [131 kB]
Get:10 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnspr4 amd64 2:4.32-3build1 [119 kB]
Get:11 http://archive.ubuntu.com/ubuntu jammy/main amd64 libnspr4-dev amd64 2:4.32-3build1 [218 kB]
Get:12 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libnss3 amd64 2:3.68.2-0ubuntu1.2 [1280 kB]
Get:13 http://archive.ubuntu.com/ubuntu jammy-updates/main amd64 libnss3-dev amd64 2:3.68.2-0ubuntu1.2 [242 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 4524 kB in 8s (550 kB/s)
Selecting previously unselected package libexpat1:amd64.
(Reading database ... 4395 files and directories currently installed.)
Preparing to unpack .../00-libexpat1_2.4.7-1ubuntu0.2_amd64.deb ...
Unpacking libexpat1:amd64 (2.4.7-1ubuntu0.2) ...
Selecting previously unselected package libsqlite3-0:amd64.
Preparing to unpack .../01-libsqlite3-0_3.37.2-2ubuntu0.1_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.37.2-2ubuntu0.1) ...
Selecting previously unselected package ucf.
Preparing to unpack .../02-ucf_3.0043_all.deb ...
Moving old data out of the way
Unpacking ucf (3.0043) ...
Selecting previously unselected package libpng16-16:amd64.
Preparing to unpack .../03-libpng16-16_1.6.37-3build5_amd64.deb ...
Unpacking libpng16-16:amd64 (1.6.37-3build5) ...
Selecting previously unselected package fonts-liberation.
 ---> 3e7d9b7ae2ee
Step 39/39 : ENTRYPOINT [ "/entrypoint.sh" ]
 ---> Running in 1da3d75f34d8
Removing intermediate container 1da3d75f34d8
 ---> f1dc06013ed0

Successfully built f1dc06013ed0
Successfully tagged wazuh/wazuh-dashboard:4.8.0
$ cd single-node/
$ docker-compose -f generate-indexer-certs.yml run --rm generator
Creating network "single-node_default" with the default driver
The tool to create the certificates exists in the in Packages bucket
16/11/2023 10:59:14 INFO: Admin certificates created.
16/11/2023 10:59:14 INFO: Wazuh indexer certificates created.
16/11/2023 10:59:14 INFO: Wazuh server certificates created.
16/11/2023 10:59:14 INFO: Wazuh dashboard certificates created.
Moving created certificates to the destination directory
Changing certificate permissions
Setting UID indexer and dashboard
Setting UID for wazuh manager and worker
$ docker-compose up -d
Creating volume "single-node_wazuh_api_configuration" with default driver
Creating volume "single-node_wazuh_etc" with default driver
Creating volume "single-node_wazuh_logs" with default driver
Creating volume "single-node_wazuh_queue" with default driver
Creating volume "single-node_wazuh_var_multigroups" with default driver
Creating volume "single-node_wazuh_integrations" with default driver
Creating volume "single-node_wazuh_active_response" with default driver
Creating volume "single-node_wazuh_agentless" with default driver
Creating volume "single-node_wazuh_wodles" with default driver
Creating volume "single-node_filebeat_etc" with default driver
Creating volume "single-node_filebeat_var" with default driver
Creating volume "single-node_wazuh-indexer-data" with default driver
Creating volume "single-node_wazuh-dashboard-config" with default driver
Creating volume "single-node_wazuh-dashboard-custom" with default driver
Creating single-node_wazuh.indexer_1 ... done
Creating single-node_wazuh.manager_1 ... done
Creating single-node_wazuh.dashboard_1 ... done
```
</details>
