### PR TITLE
Removed report dependencies from Wazuh dashboard image

### DIFF
--- a/build-docker-images/wazuh-dashboard/Dockerfile
+++ b/build-docker-images/wazuh-dashboard/Dockerfile
@@ -80,9 +80,6 @@ ENV PATTERN="" \
     WAZUH_MONITORING_SHARDS="" \
     WAZUH_MONITORING_REPLICAS=""
 
-# Install dependencies
-RUN apt update && apt install -y libnss3-dev fonts-liberation libfontconfig1
-
 # Create wazuh-dashboard user and group
 RUN getent group $GROUP || groupadd -r -g 1000 $GROUP
 RUN useradd --system \


### PR DESCRIPTION
Related https://github.com/wazuh/internal-devel-requests/issues/492

<details>
<summary>Docker images build</summary>

```console
Building wazuh.dashboard
Sending build context to Docker daemon  25.09kB
Step 1/38 : FROM ubuntu:focal AS builder
 ---> bf40b7bc7a11
Step 2/38 : ARG WAZUH_VERSION
 ---> Running in 328259785ee8
Removing intermediate container 328259785ee8
 ---> 6eee2e0c0467
Step 3/38 : ARG WAZUH_TAG_REVISION
 ---> Running in a952c5cd30c9
Removing intermediate container a952c5cd30c9
 ---> 216994b3819f
Step 4/38 : ARG INSTALL_DIR=/usr/share/wazuh-dashboard
 ---> Running in ab86a8b3cf87
Removing intermediate container ab86a8b3cf87
 ---> 8ab67c218a82
Step 5/38 : ARG WAZUH_UI_REVISION
 ---> Running in 510a99e3c61e
Removing intermediate container 510a99e3c61e
 ---> df2dcddbaf0d
Step 6/38 : RUN apt-get update && apt install curl libcap2-bin xz-utils -y
 ---> Running in ae301e621def
Get:1 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]
Get:2 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [11.3 MB]
Get:6 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [29.3 kB]
Get:7 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [1129 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [1275 kB]
Get:9 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [3057 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [33.4 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [177 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1433 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [32.0 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [3206 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [3709 kB]
Get:16 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [55.2 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [28.6 kB]
Get:18 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [3221 kB]
Fetched 29.3 MB in 6s (4798 kB/s)
Reading package lists...

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  ca-certificates krb5-locales libasn1-8-heimdal libbrotli1 libcap2 libcurl4
  libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal
  libheimntlm0-heimdal libhx509-5-heimdal libk5crypto3 libkeyutils1
  libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2 libldap-common
  libnghttp2-14 libpam-cap libpsl5 libroken18-heimdal librtmp1 libsasl2-2
  libsasl2-modules libsasl2-modules-db libsqlite3-0 libssh-4 libssl1.1
  libwind0-heimdal openssl publicsuffix
Suggested packages:
  krb5-doc krb5-user libsasl2-modules-gssapi-mit
  | libsasl2-modules-gssapi-heimdal libsasl2-modules-ldap libsasl2-modules-otp
  libsasl2-modules-sql
The following NEW packages will be installed:
  ca-certificates curl krb5-locales libasn1-8-heimdal libbrotli1 libcap2
  libcap2-bin libcurl4 libgssapi-krb5-2 libgssapi3-heimdal libhcrypto4-heimdal
  libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libk5crypto3
  libkeyutils1 libkrb5-26-heimdal libkrb5-3 libkrb5support0 libldap-2.4-2
  libldap-common libnghttp2-14 libpam-cap libpsl5 libroken18-heimdal librtmp1
  libsasl2-2 libsasl2-modules libsasl2-modules-db libsqlite3-0 libssh-4
  libssl1.1 libwind0-heimdal openssl publicsuffix xz-utils
0 upgraded, 36 newly installed, 0 to remove and 5 not upgraded.
Need to get 5588 kB of archives.
After this operation, 17.3 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libssl1.1 amd64 1.1.1f-1ubuntu2.20 [1321 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 openssl amd64 1.1.1f-1ubuntu2.20 [620 kB]
Get:3 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 ca-certificates all 20230311ubuntu0.20.04.1 [152 kB]
Get:4 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcap2 amd64 1:2.32-1ubuntu0.1 [15.8 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcap2-bin amd64 1:2.32-1ubuntu0.1 [26.2 kB]
Get:6 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libpam-cap amd64 1:2.32-1ubuntu0.1 [8364 B]
Get:7 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsqlite3-0 amd64 3.31.1-4ubuntu0.5 [549 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 xz-utils amd64 5.2.4-1ubuntu1.1 [82.6 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 krb5-locales all 1.17-6ubuntu4.4 [11.5 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libkrb5support0 amd64 1.17-6ubuntu4.4 [31.0 kB]
Get:11 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libk5crypto3 amd64 1.17-6ubuntu4.4 [79.9 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libkeyutils1 amd64 1.6-6ubuntu1.1 [10.3 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libkrb5-3 amd64 1.17-6ubuntu4.4 [330 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgssapi-krb5-2 amd64 1.17-6ubuntu4.4 [121 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal/main amd64 libpsl5 amd64 0.21.0-1ubuntu1 [51.5 kB]
Get:16 http://archive.ubuntu.com/ubuntu focal/main amd64 publicsuffix all 20200303.0012-1 [111 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libbrotli1 amd64 1.0.7-6ubuntu0.1 [267 kB]
Get:18 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libroken18-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [42.5 kB]
Get:19 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libasn1-8-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [181 kB]
Get:20 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libheimbase1-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [30.4 kB]
Get:21 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libhcrypto4-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [88.1 kB]
Get:22 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libwind0-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [47.7 kB]
Get:23 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libhx509-5-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [107 kB]
Get:24 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libkrb5-26-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [207 kB]
Get:25 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libheimntlm0-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [15.1 kB]
Get:26 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libgssapi3-heimdal amd64 7.7.0+dfsg-1ubuntu1.4 [96.5 kB]
Get:27 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsasl2-modules-db amd64 2.1.27+dfsg-2ubuntu0.1 [14.7 kB]
Get:28 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsasl2-2 amd64 2.1.27+dfsg-2ubuntu0.1 [49.3 kB]
Get:29 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libldap-common all 2.4.49+dfsg-2ubuntu1.9 [16.6 kB]
Get:30 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libldap-2.4-2 amd64 2.4.49+dfsg-2ubuntu1.9 [155 kB]
Get:31 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libnghttp2-14 amd64 1.40.0-1ubuntu0.1 [78.5 kB]
Get:32 http://archive.ubuntu.com/ubuntu focal/main amd64 librtmp1 amd64 2.4+20151223.gitfa8646d.1-2build1 [54.9 kB]
Get:33 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libssh-4 amd64 0.9.3-2ubuntu2.3 [170 kB]
Get:34 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4 amd64 7.68.0-1ubuntu2.20 [235 kB]
Get:35 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 curl amd64 7.68.0-1ubuntu2.20 [161 kB]
Get:36 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 libsasl2-modules amd64 2.1.27+dfsg-2ubuntu0.1 [48.8 kB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 5588 kB in 9s (600 kB/s)
Selecting previously unselected package libssl1.1:amd64.
(Reading database ... 4126 files and directories currently installed.)
Preparing to unpack .../00-libssl1.1_1.1.1f-1ubuntu2.20_amd64.deb ...
Unpacking libssl1.1:amd64 (1.1.1f-1ubuntu2.20) ...
Selecting previously unselected package openssl.
Preparing to unpack .../01-openssl_1.1.1f-1ubuntu2.20_amd64.deb ...
Unpacking openssl (1.1.1f-1ubuntu2.20) ...
Selecting previously unselected package ca-certificates.
Preparing to unpack .../02-ca-certificates_20230311ubuntu0.20.04.1_all.deb ...
Unpacking ca-certificates (20230311ubuntu0.20.04.1) ...
Selecting previously unselected package libcap2:amd64.
Preparing to unpack .../03-libcap2_1%3a2.32-1ubuntu0.1_amd64.deb ...
Unpacking libcap2:amd64 (1:2.32-1ubuntu0.1) ...
Selecting previously unselected package libcap2-bin.
Preparing to unpack .../04-libcap2-bin_1%3a2.32-1ubuntu0.1_amd64.deb ...
Unpacking libcap2-bin (1:2.32-1ubuntu0.1) ...
Selecting previously unselected package libpam-cap:amd64.
Preparing to unpack .../05-libpam-cap_1%3a2.32-1ubuntu0.1_amd64.deb ...
Unpacking libpam-cap:amd64 (1:2.32-1ubuntu0.1) ...
Selecting previously unselected package libsqlite3-0:amd64.
Preparing to unpack .../06-libsqlite3-0_3.31.1-4ubuntu0.5_amd64.deb ...
Unpacking libsqlite3-0:amd64 (3.31.1-4ubuntu0.5) ...
Selecting previously unselected package xz-utils.
Preparing to unpack .../07-xz-utils_5.2.4-1ubuntu1.1_amd64.deb ...
Unpacking xz-utils (5.2.4-1ubuntu1.1) ...
Selecting previously unselected package krb5-locales.
Preparing to unpack .../08-krb5-locales_1.17-6ubuntu4.4_all.deb ...
Unpacking krb5-locales (1.17-6ubuntu4.4) ...
Selecting previously unselected package libkrb5support0:amd64.
Preparing to unpack .../09-libkrb5support0_1.17-6ubuntu4.4_amd64.deb ...
Unpacking libkrb5support0:amd64 (1.17-6ubuntu4.4) ...
Selecting previously unselected package libk5crypto3:amd64.
Preparing to unpack .../10-libk5crypto3_1.17-6ubuntu4.4_amd64.deb ...
Unpacking libk5crypto3:amd64 (1.17-6ubuntu4.4) ...
Selecting previously unselected package libkeyutils1:amd64.
Preparing to unpack .../11-libkeyutils1_1.6-6ubuntu1.1_amd64.deb ...
Unpacking libkeyutils1:amd64 (1.6-6ubuntu1.1) ...
Selecting previously unselected package libkrb5-3:amd64.
Preparing to unpack .../12-libkrb5-3_1.17-6ubuntu4.4_amd64.deb ...
Unpacking libkrb5-3:amd64 (1.17-6ubuntu4.4) ...
Selecting previously unselected package libgssapi-krb5-2:amd64.
Preparing to unpack .../13-libgssapi-krb5-2_1.17-6ubuntu4.4_amd64.deb ...
Unpacking libgssapi-krb5-2:amd64 (1.17-6ubuntu4.4) ...
Selecting previously unselected package libpsl5:amd64.
Preparing to unpack .../14-libpsl5_0.21.0-1ubuntu1_amd64.deb ...
Unpacking libpsl5:amd64 (0.21.0-1ubuntu1) ...
Selecting previously unselected package publicsuffix.
Preparing to unpack .../15-publicsuffix_20200303.0012-1_all.deb ...
Unpacking publicsuffix (20200303.0012-1) ...
Selecting previously unselected package libbrotli1:amd64.
Preparing to unpack .../16-libbrotli1_1.0.7-6ubuntu0.1_amd64.deb ...
Unpacking libbrotli1:amd64 (1.0.7-6ubuntu0.1) ...
Selecting previously unselected package libroken18-heimdal:amd64.
Preparing to unpack .../17-libroken18-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libroken18-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libasn1-8-heimdal:amd64.
Preparing to unpack .../18-libasn1-8-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libasn1-8-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libheimbase1-heimdal:amd64.
Preparing to unpack .../19-libheimbase1-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libheimbase1-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libhcrypto4-heimdal:amd64.
Preparing to unpack .../20-libhcrypto4-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libhcrypto4-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libwind0-heimdal:amd64.
Preparing to unpack .../21-libwind0-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libwind0-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libhx509-5-heimdal:amd64.
Preparing to unpack .../22-libhx509-5-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libhx509-5-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libkrb5-26-heimdal:amd64.
Preparing to unpack .../23-libkrb5-26-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libkrb5-26-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libheimntlm0-heimdal:amd64.
Preparing to unpack .../24-libheimntlm0-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libheimntlm0-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libgssapi3-heimdal:amd64.
Preparing to unpack .../25-libgssapi3-heimdal_7.7.0+dfsg-1ubuntu1.4_amd64.deb ...
Unpacking libgssapi3-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Selecting previously unselected package libsasl2-modules-db:amd64.
Preparing to unpack .../26-libsasl2-modules-db_2.1.27+dfsg-2ubuntu0.1_amd64.deb ...
Unpacking libsasl2-modules-db:amd64 (2.1.27+dfsg-2ubuntu0.1) ...
Selecting previously unselected package libsasl2-2:amd64.
Preparing to unpack .../27-libsasl2-2_2.1.27+dfsg-2ubuntu0.1_amd64.deb ...
Unpacking libsasl2-2:amd64 (2.1.27+dfsg-2ubuntu0.1) ...
Selecting previously unselected package libldap-common.
Preparing to unpack .../28-libldap-common_2.4.49+dfsg-2ubuntu1.9_all.deb ...
Unpacking libldap-common (2.4.49+dfsg-2ubuntu1.9) ...
Selecting previously unselected package libldap-2.4-2:amd64.
Preparing to unpack .../29-libldap-2.4-2_2.4.49+dfsg-2ubuntu1.9_amd64.deb ...
Unpacking libldap-2.4-2:amd64 (2.4.49+dfsg-2ubuntu1.9) ...
Selecting previously unselected package libnghttp2-14:amd64.
Preparing to unpack .../30-libnghttp2-14_1.40.0-1ubuntu0.1_amd64.deb ...
Unpacking libnghttp2-14:amd64 (1.40.0-1ubuntu0.1) ...
Selecting previously unselected package librtmp1:amd64.
Preparing to unpack .../31-librtmp1_2.4+20151223.gitfa8646d.1-2build1_amd64.deb ...
Unpacking librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build1) ...
Selecting previously unselected package libssh-4:amd64.
Preparing to unpack .../32-libssh-4_0.9.3-2ubuntu2.3_amd64.deb ...
Unpacking libssh-4:amd64 (0.9.3-2ubuntu2.3) ...
Selecting previously unselected package libcurl4:amd64.
Preparing to unpack .../33-libcurl4_7.68.0-1ubuntu2.20_amd64.deb ...
Unpacking libcurl4:amd64 (7.68.0-1ubuntu2.20) ...
Selecting previously unselected package curl.
Preparing to unpack .../34-curl_7.68.0-1ubuntu2.20_amd64.deb ...
Unpacking curl (7.68.0-1ubuntu2.20) ...
Selecting previously unselected package libsasl2-modules:amd64.
Preparing to unpack .../35-libsasl2-modules_2.1.27+dfsg-2ubuntu0.1_amd64.deb ...
Unpacking libsasl2-modules:amd64 (2.1.27+dfsg-2ubuntu0.1) ...
Setting up libkeyutils1:amd64 (1.6-6ubuntu1.1) ...
Setting up libpsl5:amd64 (0.21.0-1ubuntu1) ...
Setting up libssl1.1:amd64 (1.1.1f-1ubuntu2.20) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up libbrotli1:amd64 (1.0.7-6ubuntu0.1) ...
Setting up libsqlite3-0:amd64 (3.31.1-4ubuntu0.5) ...
Setting up libsasl2-modules:amd64 (2.1.27+dfsg-2ubuntu0.1) ...
Setting up libnghttp2-14:amd64 (1.40.0-1ubuntu0.1) ...
Setting up krb5-locales (1.17-6ubuntu4.4) ...
Setting up libldap-common (2.4.49+dfsg-2ubuntu1.9) ...
Setting up libcap2:amd64 (1:2.32-1ubuntu0.1) ...
Setting up libkrb5support0:amd64 (1.17-6ubuntu4.4) ...
Setting up libsasl2-modules-db:amd64 (2.1.27+dfsg-2ubuntu0.1) ...
Setting up libcap2-bin (1:2.32-1ubuntu0.1) ...
Setting up librtmp1:amd64 (2.4+20151223.gitfa8646d.1-2build1) ...
Setting up xz-utils (5.2.4-1ubuntu1.1) ...
update-alternatives: using /usr/bin/xz to provide /usr/bin/lzma (lzma) in auto mode
update-alternatives: warning: skip creation of /usr/share/man/man1/lzma.1.gz because associated file /usr/share/man/man1/xz.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/unlzma.1.gz because associated file /usr/share/man/man1/unxz.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzcat.1.gz because associated file /usr/share/man/man1/xzcat.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzmore.1.gz because associated file /usr/share/man/man1/xzmore.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzless.1.gz because associated file /usr/share/man/man1/xzless.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzdiff.1.gz because associated file /usr/share/man/man1/xzdiff.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzcmp.1.gz because associated file /usr/share/man/man1/xzcmp.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzgrep.1.gz because associated file /usr/share/man/man1/xzgrep.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzegrep.1.gz because associated file /usr/share/man/man1/xzegrep.1.gz (of link group lzma) doesn't exist
update-alternatives: warning: skip creation of /usr/share/man/man1/lzfgrep.1.gz because associated file /usr/share/man/man1/xzfgrep.1.gz (of link group lzma) doesn't exist
Setting up libk5crypto3:amd64 (1.17-6ubuntu4.4) ...
Setting up libsasl2-2:amd64 (2.1.27+dfsg-2ubuntu0.1) ...
Setting up libroken18-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libkrb5-3:amd64 (1.17-6ubuntu4.4) ...
Setting up openssl (1.1.1f-1ubuntu2.20) ...
Setting up libpam-cap:amd64 (1:2.32-1ubuntu0.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Setting up publicsuffix (20200303.0012-1) ...
Setting up libheimbase1-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libasn1-8-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libhcrypto4-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up ca-certificates (20230311ubuntu0.20.04.1) ...
debconf: unable to initialize frontend: Dialog
debconf: (TERM is not set, so the dialog frontend is not usable.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.30.0 /usr/local/share/perl/5.30.0 /usr/lib/x86_64-linux-gnu/perl5/5.30 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.30 /usr/share/perl/5.30 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
debconf: falling back to frontend: Teletype
Updating certificates in /etc/ssl/certs...
137 added, 0 removed; done.
Setting up libwind0-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libgssapi-krb5-2:amd64 (1.17-6ubuntu4.4) ...
Setting up libssh-4:amd64 (0.9.3-2ubuntu2.3) ...
Setting up libhx509-5-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libkrb5-26-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libheimntlm0-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libgssapi3-heimdal:amd64 (7.7.0+dfsg-1ubuntu1.4) ...
Setting up libldap-2.4-2:amd64 (2.4.49+dfsg-2ubuntu1.9) ...
Setting up libcurl4:amd64 (7.68.0-1ubuntu2.20) ...
Setting up curl (7.68.0-1ubuntu2.20) ...
Processing triggers for libc-bin (2.31-0ubuntu9.12) ...
Processing triggers for ca-certificates (20230311ubuntu0.20.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Removing intermediate container ae301e621def
 ---> b31338848cf6
Step 7/38 : RUN mkdir -p $INSTALL_DIR
 ---> Running in 9e200febfc6f
Removing intermediate container 9e200febfc6f
 ---> 3ad05eea7c32
Step 8/38 : COPY config/dl_base.sh .
 ---> 29b17f1a79fb
Step 9/38 : RUN bash dl_base.sh
 ---> Running in 6280f684d5ee
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  151M  100  151M    0     0  6881k      0  0:00:22  0:00:22 --:--:-- 7271k
Removing intermediate container 6280f684d5ee
 ---> 1f204412f6c6
Step 10/38 : COPY config/config.sh .
 ---> 47d177d1b89b
Step 11/38 : COPY config/config.yml /
 ---> c13b530b85e0
Step 12/38 : RUN bash config.sh
 ---> Running in 1168add105cb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32077  100 32077    0     0   100k      0 --:--:-- --:--:-- --:--:--  100k
Cert tool exists in Packages-dev bucket
21/11/2023 17:45:24 INFO: Admin certificates created.
21/11/2023 17:45:25 INFO: Wazuh dashboard certificates created.
Removing intermediate container 1168add105cb
 ---> 10ae6c510a47
Step 13/38 : COPY config/install_wazuh_app.sh /
 ---> 997c3bf9bab1
Step 14/38 : RUN chmod 775 /install_wazuh_app.sh
 ---> Running in f7fa253a0215
Removing intermediate container f7fa253a0215
 ---> ee9bfb436f91
Step 15/38 : RUN bash /install_wazuh_app.sh
 ---> Running in 1e2a6a8ce242
v16.20.0
Attempting to transfer from https://packages-dev.wazuh.com/pre-release/ui/dashboard/wazuh-4.7.0-1.zip
Transferring 34967687 bytes....................
Transfer complete
Retrieving metadata from plugin archive
Extracting plugin archive
Extraction complete
Plugin installation complete
Removing intermediate container 1e2a6a8ce242
 ---> 1fdd09286cea
Step 16/38 : COPY config/opensearch_dashboards.yml $INSTALL_DIR/config/
 ---> 1f6540247e40
Step 17/38 : COPY config/wazuh.yml $INSTALL_DIR/data/wazuh/config/
 ---> 8597643ae4dc
Step 18/38 : RUN chown 101:101 $INSTALL_DIR/config/opensearch_dashboards.yml && chmod 664 $INSTALL_DIR/config/opensearch_dashboards.yml
 ---> Running in 2602a749e00e
Removing intermediate container 2602a749e00e
 ---> f728448a3c1b
Step 19/38 : RUN mkdir -p $INSTALL_DIR/data/wazuh && chown -R 101:101 $INSTALL_DIR/data/wazuh && chmod -R 775 $INSTALL_DIR/data/wazuh
 ---> Running in cda92d31e98c
Removing intermediate container cda92d31e98c
 ---> 3ad7fe3b24e0
Step 20/38 : RUN mkdir -p $INSTALL_DIR/data/wazuh/config && chown -R 101:101 $INSTALL_DIR/data/wazuh/config && chmod -R 775 $INSTALL_DIR/data/wazuh/config
 ---> Running in 326cc24790d5
Removing intermediate container 326cc24790d5
 ---> 3edd28ba6613
Step 21/38 : RUN mkdir -p $INSTALL_DIR/data/wazuh/logs && chown -R 101:101 $INSTALL_DIR/data/wazuh/logs && chmod -R 775 $INSTALL_DIR/data/wazuh/logs
 ---> Running in 489b4192f180
Removing intermediate container 489b4192f180
 ---> 7a587f75b622
Step 22/38 : FROM ubuntu:focal
 ---> bf40b7bc7a11
Step 23/38 : ENV USER="wazuh-dashboard"     GROUP="wazuh-dashboard"     NAME="wazuh-dashboard"     INSTALL_DIR="/usr/share/wazuh-dashboard"
 ---> Running in d5b090ffcf96
Removing intermediate container d5b090ffcf96
 ---> 0a688eb558b0
Step 24/38 : ENV PATTERN=""     CHECKS_PATTERN=""     CHECKS_TEMPLATE=""     CHECKS_API=""     CHECKS_SETUP=""     EXTENSIONS_PCI=""     EXTENSIONS_GDPR=""     EXTENSIONS_HIPAA=""     EXTENSIONS_NIST=""     EXTENSIONS_TSC=""     EXTENSIONS_AUDIT=""     EXTENSIONS_OSCAP=""     EXTENSIONS_CISCAT=""     EXTENSIONS_AWS=""     EXTENSIONS_GCP=""     EXTENSIONS_GITHUB=""    EXTENSIONS_OFFICE=""    EXTENSIONS_VIRUSTOTAL=""     EXTENSIONS_OSQUERY=""     EXTENSIONS_DOCKER=""     APP_TIMEOUT=""     API_SELECTOR=""     IP_SELECTOR=""     IP_IGNORE=""     WAZUH_MONITORING_ENABLED=""     WAZUH_MONITORING_FREQUENCY=""     WAZUH_MONITORING_SHARDS=""     WAZUH_MONITORING_REPLICAS=""
 ---> Running in 45705b2980c6
Removing intermediate container 45705b2980c6
 ---> 1a7dd47d2bd7
Step 25/38 : RUN getent group $GROUP || groupadd -r -g 1000 $GROUP
 ---> Running in e2dfeba0be7a
Removing intermediate container e2dfeba0be7a
 ---> b444af4c1b1d
Step 26/38 : RUN useradd --system             --uid 1000             --no-create-home             --home-dir $INSTALL_DIR             --gid $GROUP             --shell /sbin/nologin             --comment "$USER user"             $USER
 ---> Running in 304f63653d90
Removing intermediate container 304f63653d90
 ---> 541b826244d4
Step 27/38 : COPY config/entrypoint.sh /
 ---> 1392f2dfaad2
Step 28/38 : COPY config/wazuh_app_config.sh /
 ---> 0cec1bd5b287
Step 29/38 : RUN chmod 700 /entrypoint.sh
 ---> Running in a54cafdde630
Removing intermediate container a54cafdde630
 ---> 06c8820d2652
Step 30/38 : RUN chmod 700 /wazuh_app_config.sh
 ---> Running in 9410af34bdf4
Removing intermediate container 9410af34bdf4
 ---> 255d20f750ee
Step 31/38 : RUN chown 1000:1000 /*.sh
 ---> Running in ba1d3585d4dc
Removing intermediate container ba1d3585d4dc
 ---> 3cc5b879634b
Step 32/38 : COPY --from=builder --chown=1000:1000 $INSTALL_DIR $INSTALL_DIR
 ---> 25131a5bc116
Step 33/38 : RUN mkdir -p /usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom
 ---> Running in 53e43363535b
Removing intermediate container 53e43363535b
 ---> 8a4c8705a1bd
Step 34/38 : RUN chown 1000:1000 /usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom
 ---> Running in 9e4c07a45103
Removing intermediate container 9e4c07a45103
 ---> 636ce793f86d
Step 35/38 : WORKDIR $INSTALL_DIR
 ---> Running in 679b4a51b96f
Removing intermediate container 679b4a51b96f
 ---> 8d7cbc6c67d3
Step 36/38 : USER wazuh-dashboard
 ---> Running in 99ad51db4346
Removing intermediate container 99ad51db4346
 ---> 8434d358c41f
Step 37/38 : EXPOSE 443
 ---> Running in 730a5d10fbe0
Removing intermediate container 730a5d10fbe0
 ---> 267a6ee03b6e
Step 38/38 : ENTRYPOINT [ "/entrypoint.sh" ]
 ---> Running in 6b6b5055961a
Removing intermediate container 6b6b5055961a
 ---> e2ad3cc62357
Successfully built e2ad3cc62357
Successfully tagged wazuh/wazuh-dashboard:4.7.0
```
</details>


<details>
<summary>apt list installed</summary>

```console
wazuh-dashboard@wazuh:~$ apt list --installed
Listing... Done
adduser/now 3.118ubuntu2 all [installed,local]
apt/now 2.0.9 amd64 [installed,local]
base-files/now 11ubuntu5.7 amd64 [installed,local]
base-passwd/now 3.5.47 amd64 [installed,local]
bash/now 5.0-6ubuntu1.2 amd64 [installed,local]
bsdutils/now 1:2.34-0.1ubuntu9.4 amd64 [installed,local]
bzip2/now 1.0.8-2 amd64 [installed,local]
coreutils/now 8.30-3ubuntu2 amd64 [installed,local]
dash/now 0.5.10.2-6 amd64 [installed,local]
debconf/now 1.5.73 all [installed,local]
debianutils/now 4.9.1 amd64 [installed,local]
diffutils/now 1:3.7-3 amd64 [installed,local]
dpkg/now 1.19.7ubuntu3.2 amd64 [installed,local]
e2fsprogs/now 1.45.5-2ubuntu1.1 amd64 [installed,local]
fdisk/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
findutils/now 4.7.0-1ubuntu1 amd64 [installed,local]
gcc-10-base/now 10.5.0-1ubuntu1~20.04 amd64 [installed,local]
gpgv/now 2.2.19-3ubuntu2.2 amd64 [installed,local]
grep/now 3.4-1 amd64 [installed,local]
gzip/now 1.10-0ubuntu4.1 amd64 [installed,local]
hostname/now 3.23 amd64 [installed,local]
init-system-helpers/now 1.57 all [installed,local]
libacl1/now 2.2.53-6 amd64 [installed,local]
libapt-pkg6.0/now 2.0.9 amd64 [installed,local]
libattr1/now 1:2.4.48-5 amd64 [installed,local]
libaudit-common/now 1:2.8.5-2ubuntu6 all [installed,local]
libaudit1/now 1:2.8.5-2ubuntu6 amd64 [installed,local]
libblkid1/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
libbz2-1.0/now 1.0.8-2 amd64 [installed,local]
libc-bin/now 2.31-0ubuntu9.12 amd64 [installed,local]
libc6/now 2.31-0ubuntu9.12 amd64 [installed,local]
libcap-ng0/now 0.7.9-2.1build1 amd64 [installed,local]
libcom-err2/now 1.45.5-2ubuntu1.1 amd64 [installed,local]
libcrypt1/now 1:4.4.10-10ubuntu4 amd64 [installed,local]
libdb5.3/now 5.3.28+dfsg1-0.6ubuntu2 amd64 [installed,local]
libdebconfclient0/now 0.251ubuntu1 amd64 [installed,local]
libext2fs2/now 1.45.5-2ubuntu1.1 amd64 [installed,local]
libfdisk1/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
libffi7/now 3.3-4 amd64 [installed,local]
libgcc-s1/now 10.5.0-1ubuntu1~20.04 amd64 [installed,local]
libgcrypt20/now 1.8.5-5ubuntu1.1 amd64 [installed,local]
libgmp10/now 2:6.2.0+dfsg-4ubuntu0.1 amd64 [installed,local]
libgnutls30/now 3.6.13-2ubuntu1.8 amd64 [installed,local]
libgpg-error0/now 1.37-1 amd64 [installed,local]
libhogweed5/now 3.5.1+really3.5.1-2ubuntu0.2 amd64 [installed,local]
libidn2-0/now 2.2.0-2 amd64 [installed,local]
liblz4-1/now 1.9.2-2ubuntu0.20.04.1 amd64 [installed,local]
liblzma5/now 5.2.4-1ubuntu1.1 amd64 [installed,local]
libmount1/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
libncurses6/now 6.2-0ubuntu2.1 amd64 [installed,local]
libncursesw6/now 6.2-0ubuntu2.1 amd64 [installed,local]
libnettle7/now 3.5.1+really3.5.1-2ubuntu0.2 amd64 [installed,local]
libp11-kit0/now 0.23.20-1ubuntu0.1 amd64 [installed,local]
libpam-modules-bin/now 1.3.1-5ubuntu4.6 amd64 [installed,local]
libpam-modules/now 1.3.1-5ubuntu4.6 amd64 [installed,local]
libpam-runtime/now 1.3.1-5ubuntu4.6 all [installed,local]
libpam0g/now 1.3.1-5ubuntu4.6 amd64 [installed,local]
libpcre2-8-0/now 10.34-7ubuntu0.1 amd64 [installed,local]
libpcre3/now 2:8.39-12ubuntu0.1 amd64 [installed,local]
libprocps8/now 2:3.3.16-1ubuntu2.3 amd64 [installed,local]
libseccomp2/now 2.5.1-1ubuntu1~20.04.2 amd64 [installed,local]
libselinux1/now 3.0-1build2 amd64 [installed,local]
libsemanage-common/now 3.0-1build2 all [installed,local]
libsemanage1/now 3.0-1build2 amd64 [installed,local]
libsepol1/now 3.0-1ubuntu0.1 amd64 [installed,local]
libsmartcols1/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
libss2/now 1.45.5-2ubuntu1.1 amd64 [installed,local]
libstdc++6/now 10.5.0-1ubuntu1~20.04 amd64 [installed,local]
libsystemd0/now 245.4-4ubuntu3.22 amd64 [installed,local]
libtasn1-6/now 4.16.0-2 amd64 [installed,local]
libtinfo6/now 6.2-0ubuntu2.1 amd64 [installed,local]
libudev1/now 245.4-4ubuntu3.22 amd64 [installed,local]
libunistring2/now 0.9.10-2 amd64 [installed,local]
libuuid1/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
libzstd1/now 1.4.4+dfsg-3ubuntu0.1 amd64 [installed,local]
login/now 1:4.8.1-1ubuntu5.20.04.4 amd64 [installed,local]
logsave/now 1.45.5-2ubuntu1.1 amd64 [installed,local]
lsb-base/now 11.1.0ubuntu2 all [installed,local]
mawk/now 1.3.4.20200120-2 amd64 [installed,local]
mount/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
ncurses-base/now 6.2-0ubuntu2.1 all [installed,local]
ncurses-bin/now 6.2-0ubuntu2.1 amd64 [installed,local]
passwd/now 1:4.8.1-1ubuntu5.20.04.4 amd64 [installed,local]
perl-base/now 5.30.0-9ubuntu0.4 amd64 [installed,local]
procps/now 2:3.3.16-1ubuntu2.3 amd64 [installed,local]
sed/now 4.7-1 amd64 [installed,local]
sensible-utils/now 0.0.12+nmu1 all [installed,local]
sysvinit-utils/now 2.96-2.1ubuntu1 amd64 [installed,local]
tar/now 1.30+dfsg-7ubuntu0.20.04.3 amd64 [installed,local]
ubuntu-keyring/now 2020.02.11.4 all [installed,local]
util-linux/now 2.34-0.1ubuntu9.4 amd64 [installed,local]
zlib1g/now 1:1.2.11.dfsg-2ubuntu1.5 amd64 [installed,local]
wazuh-dashboard@wazuh:~$ apt list --installed | grep libnss3-dev

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

wazuh-dashboard@wazuh:~$ apt list --installed | grep fonts-liberation

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

wazuh-dashboard@wazuh:~$ apt list --installed | grep libfontconfig1  

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

wazuh-dashboard@wazuh:~$ exit
```
</details>

The report plugin continues to work after removing the dependencies:

![Screenshot_20231121_143605](https://github.com/wazuh/wazuh-docker/assets/64099752/75efd115-b6aa-4fc3-9d8d-e7c4831e11e9)
![Screenshot_20231121_150906](https://github.com/wazuh/wazuh-docker/assets/64099752/170a7ed0-7fb3-492c-887c-64b17f0bf8d4)


