### PR TITLE
Add an option to configure S3 repository to store snapshots out of the box

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ FILEBEAT_SSL_VERIFICATION_MODE=full                 # Filebeat SSL Verification 
 SSL_CERTIFICATE_AUTHORITIES=""                      # Path of Filebeat SSL CA
 SSL_CERTIFICATE=""                                  # Path of Filebeat SSL Certificate
 SSL_KEY=""                                          # Path of Filebeat SSL Key
+
+AWS_ACCESS_KEY_ID=""                                # AWS access key for an S3 Compatible Storage
+AWS_SECRET_ACCESS_KEY=""                            # AWS secret key for an S3 Compatible Storage
+AWS_REGION=""                                       # AWS region for an S3 Compatible Storage
 ```
 
 ### Dashboard

--- a/build-docker-images/README.md
+++ b/build-docker-images/README.md
@@ -26,6 +26,7 @@ Usage: build-docker-images/build-images.sh [OPTIONS]
     -d, --dev <ref>              [Optional] Set the development stage you want to build, example rc1 or beta1, not used by default.
     -f, --filebeat-module <ref>  [Optional] Set Filebeat module version. By default 0.4.
     -r, --revision <rev>         [Optional] Package revision. By default 1
+    -s, --s3-repository          [Optional] Install 'repository-s3' plugin for OpenSearch. By default false.
     -v, --version <ver>          [Optional] Set the Wazuh version should be builded. By default, 5.0.0.
     -h, --help                   Show this help.
 

--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -16,6 +16,7 @@ WAZUH_IMAGE_VERSION="5.0.0"
 WAZUH_TAG_REVISION="1"
 WAZUH_DEV_STAGE=""
 FILEBEAT_MODULE_VERSION="0.4"
+S3_REPOSITORY="false"
 
 # -----------------------------------------------------------------------------
 
@@ -69,6 +70,7 @@ build() {
     echo FILEBEAT_TEMPLATE_BRANCH=$FILEBEAT_TEMPLATE_BRANCH >> .env
     echo WAZUH_FILEBEAT_MODULE=$WAZUH_FILEBEAT_MODULE >> .env
     echo WAZUH_UI_REVISION=$WAZUH_UI_REVISION >> .env
+    echo S3_REPOSITORY=$S3_REPOSITORY >> .env
 
     docker-compose -f build-docker-images/build-images.yml --env-file .env build --no-cache
     docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/cert-tool-image/
@@ -85,6 +87,7 @@ help() {
     echo "    -d, --dev <ref>              [Optional] Set the development stage you want to build, example rc1 or beta1, not used by default."
     echo "    -f, --filebeat-module <ref>  [Optional] Set Filebeat module version. By default ${FILEBEAT_MODULE_VERSION}."
     echo "    -r, --revision <rev>         [Optional] Package revision. By default ${WAZUH_TAG_REVISION}"
+    echo "    -s, --s3-repository          [Optional] Install 'repository-s3' plugin for OpenSearch. By default ${S3_REPOSITORY}."
     echo "    -v, --version <ver>          [Optional] Set the Wazuh version should be builded. By default, ${WAZUH_IMAGE_VERSION}."
     echo "    -h, --help                   Show this help."
     echo
@@ -115,6 +118,10 @@ main() {
             else
                 help 1
             fi
+            ;;
+        "-s"|"--s3-repository")
+            S3_REPOSITORY="true"
+            shift 1
             ;;
         "-r"|"--revision")
             if [ -n "${2}" ]; then

--- a/build-docker-images/build-images.yml
+++ b/build-docker-images/build-images.yml
@@ -42,6 +42,7 @@ services:
       args:
         WAZUH_VERSION: ${WAZUH_VERSION}
         WAZUH_TAG_REVISION: ${WAZUH_TAG_REVISION}
+        S3_REPOSITORY: ${S3_REPOSITORY}
     image: wazuh/wazuh-indexer:${WAZUH_IMAGE_VERSION}
     hostname: wazuh.indexer
     restart: always

--- a/build-docker-images/wazuh-indexer/Dockerfile
+++ b/build-docker-images/wazuh-indexer/Dockerfile
@@ -30,10 +30,13 @@ RUN bash config.sh
 ################################################################################
 FROM amazonlinux:2023
 
+ARG S3_REPOSITORY
+
 ENV USER="wazuh-indexer" \
     GROUP="wazuh-indexer" \
     NAME="wazuh-indexer" \
-    INSTALL_DIR="/usr/share/wazuh-indexer"
+    INSTALL_DIR="/usr/share/wazuh-indexer" \
+    OPENSEARCH_PATH_CONF="/usr/share/wazuh-indexer"
 
 # Set $JAVA_HOME
 RUN echo "export JAVA_HOME=$INSTALL_DIR/jdk" >> /etc/profile.d/java_home.sh && \
@@ -84,6 +87,9 @@ RUN mkdir -p /var/lib/wazuh-indexer && chown 1000:1000 /var/lib/wazuh-indexer &&
     chmod 600 /usr/share/wazuh-indexer/opensearch.yml
 
 USER wazuh-indexer
+
+# Allow to use S3 Compatible Storage as a snapshot repository
+RUN if [ "$S3_REPOSITORY" = "true" ] ; then "${INSTALL_DIR}/bin/opensearch-plugin" install --batch repository-s3 ; fi
 
 # Services ports
 EXPOSE 9200


### PR DESCRIPTION
## Description
The aim of this PR is to add an ability to use S3 compatible storage for snapshot management out of the box. It is made possible by allowing to build `wazuh-indexer` docker image with additional plugin `repository-s3` installed, via a new optional `--s3-repository` parameter. Parameter `--s3-repository` is set to `false` by default. On `wazuh-indexer` container startup, if `repository-s3` plugin is installed, the system will attempt to read `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables and add their values to the OpenSearch keystore.

Example of changes to single-node/config/wazuh_indexer/wazuh.indexer.yml:
```yaml
...
s3.client.default.endpoint: minio:9000
s3.client.default.protocol: http
s3.client.default.max_retries: 3
s3.client.default.read_timeout: 50s
s3.client.default.path_style_access: true
s3.client.default.use_throttle_retries: true
```

Example of changes to single-node/docker-compose.yml:
```yaml
...
  wazuh.indexer:
    ...
    environment:
      ...
      - "AWS_ACCESS_KEY_ID=exampleAccessKeyID"
      - "AWS_SECRET_ACCESS_KEY=exampleSecretAccessKey"
      - "AWS_REGION=us-west-1"
...
```