### PR TITLE
Modify Dockerfile for Pod restart in Kubernetes

### DIFF
--- a/.github/.goss.yaml
+++ b/.github/.goss.yaml
@@ -56,7 +56,7 @@ package:
   wazuh-manager:
     installed: true
     versions:
-    - 4.8.0-1
+    - 4.8.0
 port:
   tcp:1514:
     listening: true

--- a/build-docker-images/wazuh-dashboard/Dockerfile
+++ b/build-docker-images/wazuh-dashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240131.0 AS builder
+FROM amazonlinux:2023.3.20240219.0 AS builder
 
 ARG WAZUH_VERSION
 ARG WAZUH_TAG_REVISION
@@ -42,7 +42,7 @@ RUN mkdir -p $INSTALL_DIR/data/wazuh/logs && chown -R 101:101 $INSTALL_DIR/data/
 # Add entrypoint
 # Add wazuh_app_config
 ################################################################################
-FROM amazonlinux:2023.3.20240131.0
+FROM amazonlinux:2023.3.20240219.0
 
 # Set environment variables
 ENV USER="wazuh-dashboard" \

--- a/build-docker-images/wazuh-dashboard/config/dl_base.sh
+++ b/build-docker-images/wazuh-dashboard/config/dl_base.sh
@@ -1,5 +1,5 @@
 REPOSITORY="packages.wazuh.com/4.x"
-WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
+WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '["]tag_name["]:' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
 MAJOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f1)
 MID_BUILD=$(echo $WAZUH_VERSION | cut -d. -f2)
 MINOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f3)

--- a/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
+++ b/build-docker-images/wazuh-dashboard/config/install_wazuh_app.sh
@@ -2,7 +2,7 @@
 WAZUH_APP=https://packages.wazuh.com/4.x/ui/dashboard/wazuh-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
 WAZUH_CHECK_UPDATES=https://packages.wazuh.com/4.x/ui/dashboard/wazuhCheckUpdates-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
 WAZUH_CORE=https://packages.wazuh.com/4.x/ui/dashboard/wazuhCore-${WAZUH_VERSION}-${WAZUH_UI_REVISION}.zip
-WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
+WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '["]tag_name["]:' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
 MAJOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f1)
 MID_BUILD=$(echo $WAZUH_VERSION | cut -d. -f2)
 MINOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f3)

--- a/build-docker-images/wazuh-indexer/Dockerfile
+++ b/build-docker-images/wazuh-indexer/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240131.0 AS builder
+FROM amazonlinux:2023.3.20240219.0 AS builder
 
 ARG WAZUH_VERSION
 ARG WAZUH_TAG_REVISION
@@ -29,7 +29,7 @@ RUN bash config.sh
 # Add entrypoint
 
 ################################################################################
-FROM amazonlinux:2023.3.20240131.0
+FROM amazonlinux:2023.3.20240219.0
 
 ENV USER="wazuh-indexer" \
     GROUP="wazuh-indexer" \

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -23,7 +23,7 @@ rm -rf ${INSTALLATION_DIR}/
 
 ## variables
 REPOSITORY="packages.wazuh.com/4.x"
-WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
+WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '["]tag_name["]:' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
 MAJOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f1)
 MID_BUILD=$(echo $WAZUH_VERSION | cut -d. -f2)
 MINOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f3)

--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240131.0
+FROM amazonlinux:2023.3.20240219.0
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
@@ -25,14 +25,12 @@ RUN yum install wazuh-manager-${WAZUH_VERSION}-${WAZUH_TAG_REVISION} -y && \
     yum clean all && \
     chmod 775 /filebeat_module.sh && \
     source /filebeat_module.sh && \
+    rm /filebeat_module.sh && \
     curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz \
     -o /tmp/s6-overlay-amd64.tar.gz && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" && \
     tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin && \
-    rm  /tmp/s6-overlay-amd64.tar.gz && \
-    chmod 755 /permanent_data.sh && \
-    sync && /permanent_data.sh && \
-    sync && rm /permanent_data.sh
+    rm  /tmp/s6-overlay-amd64.tar.gz
 
 COPY config/etc/ /etc/
 COPY --chown=root:wazuh config/create_user.py /var/ossec/framework/scripts/create_user.py
@@ -57,7 +55,10 @@ RUN mkdir -p /var/ossec/var/multigroups && \
     chmod 770 /var/ossec/agentless && \
     mkdir -p /var/ossec/active-response/bin && \
     chown root:wazuh /var/ossec/active-response/bin && \
-    chmod 770 /var/ossec/active-response/bin
+    chmod 770 /var/ossec/active-response/bin && \
+    chmod 755 /permanent_data.sh && \
+    sync && /permanent_data.sh && \
+    sync && rm /permanent_data.sh
 
 # Services ports
 EXPOSE 55000/tcp 1514/tcp 1515/tcp 514/udp 1516/tcp

--- a/build-docker-images/wazuh-manager/config/filebeat_module.sh
+++ b/build-docker-images/wazuh-manager/config/filebeat_module.sh
@@ -1,5 +1,5 @@
 REPOSITORY="packages.wazuh.com/4.x"
-WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '\"tag_name\":' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
+WAZUH_CURRENT_VERSION=$(curl --silent https://api.github.com/repos/wazuh/wazuh/releases/latest | grep '["]tag_name["]:' | sed -E 's/.*\"([^\"]+)\".*/\1/' | cut -c 2-)
 MAJOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f1)
 MID_BUILD=$(echo $WAZUH_VERSION | cut -d. -f2)
 MINOR_BUILD=$(echo $WAZUH_VERSION | cut -d. -f3)


### PR DESCRIPTION
This PR fixes Wazuh manager Dockerfile because the execution order made issues when the container was deployed in Kubernetes.
Added correction to some warning messages for certain characters used with the grep command, which in the version containing the new base image generated warnings.
The version of the base image was also updated.
Related issue https://github.com/wazuh/wazuh-kubernetes/issues/596