### PR TITLE
Delete syslog and dpkg log configuration

### DIFF
--- a/multi-node/config/wazuh_cluster/wazuh_manager.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_manager.conf
@@ -307,9 +307,4 @@
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
 </ossec_config>

--- a/multi-node/config/wazuh_cluster/wazuh_worker.conf
+++ b/multi-node/config/wazuh_cluster/wazuh_worker.conf
@@ -307,9 +307,4 @@
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
-
 </ossec_config>


### PR DESCRIPTION
This PR deletes configuration about `/var/log/dpkg.log` into `ossec.conf` file.
Related Issue https://github.com/wazuh/wazuh/issues/22511