### PR TITLE
securityadmin commented lines in Wazuh indexer entrypoint removed

### DIFF
--- a/build-docker-images/wazuh-indexer/config/entrypoint.sh
+++ b/build-docker-images/wazuh-indexer/config/entrypoint.sh
@@ -84,10 +84,4 @@ if [[ "$(id -u)" == "0" ]]; then
 fi
 
 
-#if [[ "$DISCOVERY" == "single-node" ]] && [[ ! -f "/var/lib/wazuh-indexer/.flag" ]]; then
-  # run securityadmin.sh for single node with CACERT, CERT and KEY parameter
-#  nohup /securityadmin.sh &
-#  touch "/var/lib/wazuh-indexer/.flag"
-#fi
-
 run_as_other_user_if_needed /usr/share/wazuh-indexer/bin/opensearch <<<"$KEYSTORE_PASSWORD"


### PR DESCRIPTION
Removed securityadmin execution on wazuh-docker/build-docker-images/wazuh-indexer/config/entrypoint.sh
Closes https://github.com/wazuh/wazuh-docker/issues/1291#issue-2231921180
Build check fails because there are still no packages of 5.0.0 version. It's expected to fail on that check.