### PR TITLE
Fix 4.8.0 beta-5 AL2023 Vulnerabilities

### DIFF
--- a/build-docker-images/wazuh-dashboard/Dockerfile
+++ b/build-docker-images/wazuh-dashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240304.0 AS builder
+FROM amazonlinux:2023 AS builder
 
 ARG WAZUH_VERSION
 ARG WAZUH_TAG_REVISION
@@ -42,7 +42,7 @@ RUN mkdir -p $INSTALL_DIR/data/wazuh/logs && chmod -R 775 $INSTALL_DIR/data/wazu
 # Add entrypoint
 # Add wazuh_app_config
 ################################################################################
-FROM amazonlinux:2023.3.20240304.0
+FROM amazonlinux:2023
 
 # Set environment variables
 ENV USER="wazuh-dashboard" \

--- a/build-docker-images/wazuh-indexer/Dockerfile
+++ b/build-docker-images/wazuh-indexer/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240304.0 AS builder
+FROM amazonlinux:2023 AS builder
 
 ARG WAZUH_VERSION
 ARG WAZUH_TAG_REVISION
@@ -29,7 +29,7 @@ RUN bash config.sh
 # Add entrypoint
 
 ################################################################################
-FROM amazonlinux:2023.3.20240304.0
+FROM amazonlinux:2023
 
 ENV USER="wazuh-indexer" \
     GROUP="wazuh-indexer" \

--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-FROM amazonlinux:2023.3.20240304.0
+FROM amazonlinux:2023
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 


### PR DESCRIPTION
Related issue: #1293 
Changed Docker base image from `amazonlinux:2023.3.20240304.0` to `amazonlinux:2023` as this change fixes the following known vulnerabilities:
| Vulnerability | Package |
|-----------|-----------|
| ALAS-2024-573 | python3-rpm |
| ALAS-2024-581 | libcurl-minimal |
| ALAS-2024-576 | expat |

Following, the manager, indexer and dashboard images have been built without issues.
![docker-images](https://github.com/wazuh/wazuh-docker/assets/93655331/21047b5b-808c-4fa4-ba25-a15e8be7f35c)

Finally, they deployment was made and it was validated that it did without any issue.
![Captura desde 2024-04-10 11-42-47](https://github.com/wazuh/wazuh-docker/assets/93655331/788dea59-805d-4b23-b66c-a004d30454a3)

I have also run the grype vulnerability scanner on this image and this is the result:
```
grype amazonlinux:2023 -o table
 ✔ Vulnerability DB                [updated]
 ✔ Pulled image
 ✔ Loaded image                                                        amazonlinux:2023.4.20240401.1
 ✔ Parsed image                    sha256:8395af9ef0b53df535732e1e12e1f2e99b6fb57f6b781431e6410f930b
 ✔ Cataloged contents               abc9bdf55348cb0fc3369546025cb70f452c501fbedf5af4f48e484323d91822
   ├── ✔ Packages                        [108 packages]
   ├── ✔ File digests                    [5,060 files]
   ├── ✔ File metadata                   [5,060 locations]
   └── ✔ Executables                     [272 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found 
```

