### PR TITLE
Add eazuh.yml file in the Wazuh dashboard image build process

### DIFF
--- a/build-docker-images/wazuh-dashboard/Dockerfile
+++ b/build-docker-images/wazuh-dashboard/Dockerfile
@@ -4,6 +4,7 @@ FROM amazonlinux:2023 AS builder
 ARG WAZUH_VERSION
 ARG WAZUH_TAG_REVISION
 ARG WAZUH_UI_REVISION
+ARG INSTALL_DIR=/usr/share/wazuh-dashboard
 
 # Update and install dependencies
 RUN yum install curl-minimal libcap openssl -y
@@ -14,6 +15,12 @@ RUN chmod 775 /check_repository.sh && \
 
 RUN yum install wazuh-dashboard-${WAZUH_VERSION}-${WAZUH_TAG_REVISION} -y && \
     yum clean all
+
+# Create and set permissions to data directories
+RUN mkdir -p $INSTALL_DIR/data/wazuh && chmod -R 775 $INSTALL_DIR/data/wazuh
+RUN mkdir -p $INSTALL_DIR/data/wazuh/config && chmod -R 775 $INSTALL_DIR/data/wazuh/config
+RUN mkdir -p $INSTALL_DIR/data/wazuh/logs && chmod -R 775 $INSTALL_DIR/data/wazuh/logs
+COPY config/wazuh.yml $INSTALL_DIR/data/wazuh/config/
 
 # Generate certificates
 COPY config/config.sh .

--- a/build-docker-images/wazuh-dashboard/config/wazuh.yml
+++ b/build-docker-images/wazuh-dashboard/config/wazuh.yml
@@ -1,0 +1,155 @@
+---
+#
+# Wazuh app - App configuration file
+# Copyright (C) 2017, Wazuh Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# Find more information about this on the LICENSE file.
+#
+# ======================== Wazuh app configuration file ========================
+#
+# Please check the documentation for more information on configuration options:
+# https://documentation.wazuh.com/current/installation-guide/index.html
+#
+# Also, you can check our repository:
+# https://github.com/wazuh/wazuh-dashboard-plugins
+#
+# ------------------------------- Index patterns -------------------------------
+#
+# Default index pattern to use.
+#pattern: wazuh-alerts-*
+#
+# ----------------------------------- Checks -----------------------------------
+#
+# Defines which checks must to be consider by the healthcheck
+# step once the Wazuh app starts. Values must to be true or false.
+#checks.pattern : true
+#checks.template: true
+#checks.api     : true
+#checks.setup   : true
+#checks.metaFields: true
+#
+# --------------------------------- Extensions ---------------------------------
+#
+# Defines which extensions should be activated when you add a new API entry.
+# You can change them after Wazuh app starts.
+# Values must to be true or false.
+#extensions.pci       : true
+#extensions.gdpr      : true
+#extensions.hipaa     : true
+#extensions.nist      : true
+#extensions.tsc       : true
+#extensions.audit     : true
+#extensions.oscap     : false
+#extensions.ciscat    : false
+#extensions.aws       : false
+#extensions.gcp       : false
+#extensions.virustotal: false
+#extensions.osquery   : false
+#extensions.docker    : false
+#
+# ---------------------------------- Time out ----------------------------------
+#
+# Defines maximum timeout to be used on the Wazuh app requests.
+# It will be ignored if it is bellow 1500.
+# It means milliseconds before we consider a request as failed.
+# Default: 20000
+#timeout: 20000
+#
+# -------------------------------- API selector --------------------------------
+#
+# Defines if the user is allowed to change the selected
+# API directly from the Wazuh app top menu.
+# Default: true
+#api.selector: true
+#
+# --------------------------- Index pattern selector ---------------------------
+#
+# Defines if the user is allowed to change the selected
+# index pattern directly from the Wazuh app top menu.
+# Default: true
+#ip.selector: true
+#
+# List of index patterns to be ignored
+#ip.ignore: []
+#
+# ------------------------------ wazuh-monitoring ------------------------------
+#
+# Custom setting to enable/disable wazuh-monitoring indices.
+# Values: true, false, worker
+# If worker is given as value, the app will show the Agents status
+# visualization but won't insert data on wazuh-monitoring indices.
+# Default: true
+#wazuh.monitoring.enabled: true
+#
+# Custom setting to set the frequency for wazuh-monitoring indices cron task.
+# Default: 900 (s)
+#wazuh.monitoring.frequency: 900
+#
+# Configure wazuh-monitoring-* indices shards and replicas.
+#wazuh.monitoring.shards: 2
+#wazuh.monitoring.replicas: 0
+#
+# Configure wazuh-monitoring-* indices custom creation interval.
+# Values: h (hourly), d (daily), w (weekly), m (monthly)
+# Default: d
+#wazuh.monitoring.creation: d
+#
+# Default index pattern to use for Wazuh monitoring
+#wazuh.monitoring.pattern: wazuh-monitoring-*
+#
+# --------------------------------- wazuh-cron ----------------------------------
+#
+# Customize the index prefix of predefined jobs
+# This change is not retroactive, if you change it new indexes will be created
+# cron.prefix: test
+#
+# ------------------------------ wazuh-statistics -------------------------------
+#
+# Custom setting to enable/disable statistics tasks.
+#cron.statistics.status: true
+#
+# Enter the ID of the APIs you want to save data from, leave this empty to run
+# the task on all configured APIs
+#cron.statistics.apis: []
+#
+# Define the frequency of task execution using cron schedule expressions
+#cron.statistics.interval: 0 0 * * * *
+#
+# Define the name of the index in which the documents are to be saved.
+#cron.statistics.index.name: statistics
+#
+# Define the interval in which the index will be created
+#cron.statistics.index.creation: w
+#
+# ------------------------------- App privileges --------------------------------
+#admin: true
+#
+# ---------------------------- Hide manager alerts ------------------------------
+# Hide the alerts of the manager in all dashboards and discover
+#hideManagerAlerts: false
+#
+# ------------------------------- App logging level -----------------------------
+# Set the logging level for the Wazuh App log files.
+# Default value: info
+# Allowed values: info, debug
+#logs.level: info
+#
+# -------------------------------- Enrollment DNS -------------------------------
+# Set the variable WAZUH_REGISTRATION_SERVER in agents deployment.
+# Default value: ''
+#enrollment.dns: ''
+#
+#-------------------------------- API entries -----------------------------------
+#The following configuration is the default structure to define an API entry.
+#
+#hosts:
+#  - <id>:
+#     url: http(s)://<url>
+#     port: <port>
+#     username: <username>
+#     password: <password>


### PR DESCRIPTION
This PR fixes the error deploying Wazuh stack in Kubernetes, because the `wazuh.yml` file not found before the first start of the Wazuh dashbaord service.
Related Issue https://github.com/wazuh/wazuh-kubernetes/issues/758