### PR TITLE
Support for ARM64 Build - Issue 923

### DIFF
--- a/.github/workflows/push_arm64.yml
+++ b/.github/workflows/push_arm64.yml
@@ -1,0 +1,349 @@
+name: Wazuh Docker pipeline
+
+on: [pull_request]
+
+jobs:
+  build-docker-images:
+    runs-on: ubuntu22-full-arm64
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Build Wazuh images
+      run: build-docker-images/build-images.sh
+
+    - name: Create enviroment variables
+      run: cat .env > $GITHUB_ENV
+
+    - name: Create backup Docker images
+      run: |
+        mkdir -p /home/runner/work/wazuh-docker/wazuh-docker/docker-images/
+        docker save wazuh/wazuh-manager:${{env.WAZUH_IMAGE_VERSION}} -o /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-manager.tar
+        docker save wazuh/wazuh-indexer:${{env.WAZUH_IMAGE_VERSION}} -o /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-indexer.tar
+        docker save wazuh/wazuh-dashboard:${{env.WAZUH_IMAGE_VERSION}} -o /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-dashboard.tar
+        docker save wazuh/wazuh-cert-tool:${{env.WAZUH_IMAGE_VERSION}} -o /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-cert-tool.tar
+
+    - name: Temporarily save Wazuh manager Docker image
+      uses: actions/upload-artifact@v3
+      with:
+        name: docker-artifact-manager
+        path: /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-manager.tar
+        retention-days: 1
+
+    - name: Temporarily save Wazuh indexer Docker image
+      uses: actions/upload-artifact@v3
+      with:
+        name: docker-artifact-indexer
+        path: /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-indexer.tar
+        retention-days: 1
+
+    - name: Temporarily save Wazuh dashboard Docker image
+      uses: actions/upload-artifact@v3
+      with:
+        name: docker-artifact-dashboard
+        path: /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-dashboard.tar
+        retention-days: 1
+
+    - name: Temporarily save Wazuh Cert Tool Docker image
+      uses: actions/upload-artifact@v3
+      with:
+        name: docker-artifact-cert-tool
+        path: /home/runner/work/wazuh-docker/wazuh-docker/docker-images/wazuh-cert-tool.tar
+        retention-days: 1
+
+    - name: Install Goss
+      uses: e1himself/goss-installation-action@v1.0.3
+      with:
+        version: v0.3.16
+
+    - name: Execute Goss tests (wazuh-manager)
+      run: dgoss run wazuh/wazuh-manager:${{env.WAZUH_IMAGE_VERSION}}
+      env:
+        GOSS_SLEEP: 30
+        GOSS_FILE: .github/.goss.yaml
+
+  check-single-node:
+    runs-on: ubuntu-latest
+    needs: build-docker-images
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Create enviroment variables
+      run: cat .env > $GITHUB_ENV
+
+    - name: Retrieve saved Wazuh indexer Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-indexer
+
+    - name: Retrieve saved Wazuh manager Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-manager
+
+    - name: Retrieve saved Wazuh dashboard Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-dashboard
+
+    - name: Retrieve saved Wazuh Cert Tool Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-cert-tool
+
+    - name: Docker load
+      run: |
+        docker load --input ./wazuh-indexer.tar
+        docker load --input ./wazuh-dashboard.tar
+        docker load --input ./wazuh-manager.tar
+        docker load --input ./wazuh-cert-tool.tar
+        rm -rf wazuh-manager.tar wazuh-indexer.tar wazuh-dashboard.tar wazuh-cert-tool.tar
+
+
+    - name: Create single node certficates
+      run: docker-compose -f single-node/generate-certs.yml run --rm generator
+
+    - name: Start single node stack
+      run: docker-compose -f single-node/docker-compose.yml up -d
+
+    - name: Check Wazuh indexer start
+      run: |
+       sleep 60
+       status_green="`curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s | grep green | wc -l`"
+       if [[ $status_green -eq 1 ]]; then
+        curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s
+       else
+        curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s
+        exit 1
+       fi
+       status_index="`curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s | wc -l`"
+       status_index_green="`curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s | grep "green" | wc -l`"
+       if [[ $status_index_green -eq $status_index ]]; then
+        curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s
+       else
+        curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s
+        exit 1
+       fi
+
+
+    - name: Check Wazuh indexer nodes
+      run: |
+       nodes="`curl -XGET "https://0.0.0.0:9200/_cat/nodes" -u admin:SecretPassword -k -s | grep -E "indexer" | wc -l`"
+       if [[ $nodes -eq 1 ]]; then
+        echo "Wazuh indexer nodes: ${nodes}"
+       else
+        echo "Wazuh indexer nodes: ${nodes}"
+        exit 1
+       fi
+
+    - name: Check documents into wazuh-alerts index
+      run: |
+       sleep 120
+       docs="`curl -XGET "https://0.0.0.0:9200/wazuh-alerts*/_count" -u admin:SecretPassword -k -s | jq -r ".count"`"
+       if [[ $docs -gt 0 ]]; then
+        echo "wazuh-alerts index documents: ${docs}"
+       else
+        echo "wazuh-alerts index documents: ${docs}"
+        exit 1
+       fi
+
+    - name: Check Wazuh templates
+      run: |
+       qty_templates="`curl -XGET "https://0.0.0.0:9200/_cat/templates" -u admin:SecretPassword -k -s | grep -P "wazuh|wazuh-agent|wazuh-statistics" | wc -l`"
+       templates="`curl -XGET "https://0.0.0.0:9200/_cat/templates" -u admin:SecretPassword -k -s | grep -P "wazuh|wazuh-agent|wazuh-statistics"`"
+       if [[ $qty_templates -gt 3 ]]; then
+        echo "wazuh templates:"
+        echo "${templates}"
+       else
+        echo "wazuh templates:"
+        echo "${templates}"
+        exit 1
+       fi
+
+    - name: Check Wazuh manager start
+      run: |
+        services="`curl -k -s -X GET "https://0.0.0.0:55000/manager/status?pretty=true" -H  "Authorization: Bearer ${{env.TOKEN}}" | jq -r .data.affected_items | grep running | wc -l`"
+        if [[ $services -gt 9 ]]; then
+          echo "Wazuh Manager Services: ${services}"
+          echo "OK"
+        else
+          echo "Wazuh indexer nodes: ${nodes}"
+          curl -k -X GET "https://0.0.0.0:55000/manager/status?pretty=true" -H  "Authorization: Bearer ${{env.TOKEN}}" | jq -r .data.affected_items
+          exit 1
+        fi
+      env:
+        TOKEN: $(curl -s -u wazuh-wui:MyS3cr37P450r.*- -k -X GET "https://0.0.0.0:55000/security/user/authenticate?raw=true")
+
+    - name: Check filebeat output
+      run: ./.github/single-node-filebeat-check.sh
+
+    - name: Check Wazuh dashboard service URL
+      run: |
+       status=$(curl -XGET --silent  https://0.0.0.0:443/app/status -k -u admin:SecretPassword -I -s | grep -E "^HTTP" | awk  '{print $2}')
+       if [[ $status -eq 200 ]]; then
+        echo "Wazuh dashboard status: ${status}"
+       else
+        echo "Wazuh dashboard status: ${status}"
+        exit 1
+       fi
+
+    - name: Check errors in ossec.log
+      run: ./.github/single-node-log-check.sh
+
+  check-multi-node:
+    runs-on: ubuntu-latest
+    needs: build-docker-images
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Create enviroment variables
+      run: cat .env > $GITHUB_ENV
+
+    - name: free disk space
+      run: |
+        sudo swapoff -a
+        sudo rm -f /swapfile
+        sudo apt clean
+        docker rmi $(docker image ls -aq)
+        df -h
+
+    - name: Retrieve saved Wazuh dashboard Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-dashboard
+
+    - name: Retrieve saved Wazuh manager Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-manager
+
+    - name: Retrieve saved Wazuh indexer Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-indexer
+
+    - name: Retrieve saved Wazuh Cert Tool Docker image
+      uses: actions/download-artifact@v3
+      with:
+        name: docker-artifact-cert-tool
+
+    - name: Docker load
+      run: |
+        docker load --input ./wazuh-indexer.tar
+        docker load --input ./wazuh-dashboard.tar
+        docker load --input ./wazuh-manager.tar
+        docker load --input ./wazuh-cert-tool.tar
+        rm -rf wazuh-manager.tar wazuh-indexer.tar wazuh-dashboard.tar wazuh-cert-tool.tar
+
+    - name: Create multi node certficates
+      run: docker-compose -f multi-node/generate-certs.yml run --rm generator
+
+    - name: Start multi node stack
+      run: docker-compose -f multi-node/docker-compose.yml up -d
+
+    - name: Check Wazuh indexer start
+      run: |
+       until [[ `curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s | grep green | wc -l`  -eq 1 ]]
+       do
+         echo 'Waiting for Wazuh indexer start'
+         free -m
+         df -h
+         sleep 10
+       done
+       status_green="`curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s | grep green | wc -l`"
+       if [[ $status_green -eq 1 ]]; then
+        curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s
+       else
+        curl -XGET "https://0.0.0.0:9200/_cluster/health" -u admin:SecretPassword -k -s
+        exit 1
+       fi
+       status_index="`curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s | wc -l`"
+       status_index_green="`curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s | grep -E "green" | wc -l`"
+       if [[ $status_index_green -eq $status_index ]]; then
+        curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s
+       else
+        curl -XGET "https://0.0.0.0:9200/_cat/indices" -u admin:SecretPassword -k -s
+        exit 1
+       fi
+
+    - name: Check Wazuh indexer nodes
+      run: |
+       nodes="`curl -XGET "https://0.0.0.0:9200/_cat/nodes" -u admin:SecretPassword -k -s | grep -E "indexer" | wc -l`"
+       if [[ $nodes -eq 3 ]]; then
+        echo "Wazuh indexer nodes: ${nodes}"
+       else
+        echo "Wazuh indexer nodes: ${nodes}"
+        exit 1
+       fi
+
+    - name: Check documents into wazuh-alerts index
+      run: |
+       until [[ $(``curl -XGET "https://0.0.0.0:9200/wazuh-alerts*/_count" -u admin:SecretPassword -k -s | jq -r ".count"``)  -gt 0 ]]
+       do
+         echo 'Waiting for Wazuh indexer events'
+         free -m
+         df -h
+         sleep 10
+       done
+       docs="`curl -XGET "https://0.0.0.0:9200/wazuh-alerts*/_count" -u admin:SecretPassword -k -s | jq -r ".count"`"
+       if [[ $docs -gt 0 ]]; then
+        echo "wazuh-alerts index documents: ${docs}"
+       else
+        echo "wazuh-alerts index documents: ${docs}"
+        exit 1
+       fi
+
+    - name: Check Wazuh templates
+      run: |
+       qty_templates="`curl -XGET "https://0.0.0.0:9200/_cat/templates" -u admin:SecretPassword -k -s | grep "wazuh" | wc -l`"
+       templates="`curl -XGET "https://0.0.0.0:9200/_cat/templates" -u admin:SecretPassword -k -s | grep "wazuh"`"
+       if [[ $qty_templates -gt 3 ]]; then
+        echo "wazuh templates:"
+        echo "${templates}"
+       else
+        echo "wazuh templates:"
+        echo "${templates}"
+        exit 1
+       fi
+
+    - name: Check Wazuh manager start
+      run: |
+        services="`curl -k -s -X GET "https://0.0.0.0:55000/manager/status?pretty=true" -H  "Authorization: Bearer ${{env.TOKEN}}" | jq -r .data.affected_items | grep running | wc -l`"
+        if [[ $services -gt 10 ]]; then
+          echo "Wazuh Manager Services: ${services}"
+          echo "OK"
+        else
+          echo "Wazuh indexer nodes: ${nodes}"
+          curl -k -s -X GET "https://0.0.0.0:55000/manager/status?pretty=true" -H  "Authorization: Bearer ${{env.TOKEN}}" | jq -r .data.affected_items
+          exit 1
+        fi
+        nodes=$(curl -k -s -X GET "https://0.0.0.0:55000/cluster/nodes" -H "Authorization: Bearer ${{env.TOKEN}}" | jq -r ".data.affected_items[].name" | wc -l)
+        if [[ $nodes -eq 2 ]]; then
+         echo "Wazuh manager nodes: ${nodes}"
+        else
+         echo "Wazuh manager nodes: ${nodes}"
+         exit 1
+        fi
+      env:
+        TOKEN: $(curl -s -u wazuh-wui:MyS3cr37P450r.*- -k -X GET "https://0.0.0.0:55000/security/user/authenticate?raw=true")
+
+    - name: Check filebeat output
+      run: ./.github/multi-node-filebeat-check.sh
+
+    - name: Check Wazuh dashboard service URL
+      run: |
+       status=$(curl -XGET --silent  https://0.0.0.0:443/app/status -k -u admin:SecretPassword -I | grep -E "^HTTP" | awk  '{print $2}')
+       if [[ $status -eq 200 ]]; then
+        echo "Wazuh dashboard status: ${status}"
+       else
+        echo "Wazuh dashboard status: ${status}"
+        exit 1
+       fi
+
+    - name: Check errors in ossec.log
+      run: ./.github/multi-node-log-check.sh

--- a/.github/workflows/push_x64.yml
+++ b/.github/workflows/push_x64.yml
@@ -4,7 +4,7 @@ on: [pull_request]
 
 jobs:
   build-docker-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu22-full-x64
     steps:
 
     - name: Check out code

--- a/build-docker-images/wazuh-dashboard/Dockerfile
+++ b/build-docker-images/wazuh-dashboard/Dockerfile
@@ -15,6 +15,10 @@ RUN chmod 775 /check_repository.sh && \
 RUN yum install wazuh-dashboard-${WAZUH_VERSION}-${WAZUH_TAG_REVISION} -y && \
     yum clean all
 
+RUN rm -rf /usr/share/wazuh-dashboard/node
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash
+RUN yum install -y nodejs && mkdir -p /usr/share/wazuh-dashboard/node/bin && ln -s /usr/bin/node /usr/share/wazuh-dashboard/node/bin
+
 # Generate certificates
 COPY config/config.sh .
 COPY config/config.yml /
@@ -28,6 +32,9 @@ RUN bash config.sh
 # Add wazuh_app_config
 ################################################################################
 FROM amazonlinux:2023
+
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash
+RUN yum install -y nodejs
 
 # Set environment variables
 ENV USER="wazuh-dashboard" \

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -115,10 +115,11 @@ function getArch() {
 }
 
 rm -rf "${TARGET_DIR}${INSTALLATION_DIR}/jdk";
+mkdir -p "${TARGET_DIR}${INSTALLATION_DIR}/jdk";
+
 filename="jdk-22_linux-$(getArch)_bin.tar.gz";
-cd /tmp && wget "https://download.oracle.com/java/22/latest/${filename}";
-tar -xvf "$filename";
-mv "jdk-22.0.1" "${TARGET_DIR}${INSTALLATION_DIR}/jdk";
+wget -P /tmp/ "https://download.oracle.com/java/22/latest/${filename}";
+tar --strip-components=1 -C "${TARGET_DIR}${INSTALLATION_DIR}/jdk" -xvf "/tmp/${filename}";
 
 chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs
 chmod -R 400 ${TARGET_DIR}${CONFIG_DIR}/certs/*

--- a/build-docker-images/wazuh-indexer/config/config.sh
+++ b/build-docker-images/wazuh-indexer/config/config.sh
@@ -103,6 +103,26 @@ sed -i 's/-Djava.security.policy=file:\/\/\/etc\/wazuh-indexer\/opensearch-perfo
 chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs
 chmod -R 400 ${TARGET_DIR}${CONFIG_DIR}/certs/*
 
+function getArch() {
+  case $(arch) in
+    'aarch64' | 'arm64') echo "aarch64" ;;
+    'x86_64'  | 'amd64') echo "x64"     ;;
+    *)
+      echo "Architecture $(arch) not supported" >> /dev/stderr;
+      exit 1;
+    ;;
+  esac
+}
+
+rm -rf "${TARGET_DIR}${INSTALLATION_DIR}/jdk";
+filename="jdk-22_linux-$(getArch)_bin.tar.gz";
+cd /tmp && wget "https://download.oracle.com/java/22/latest/${filename}";
+tar -xvf "$filename";
+mv "jdk-22.0.1" "${TARGET_DIR}${INSTALLATION_DIR}/jdk";
+
+chmod -R 500 ${TARGET_DIR}${CONFIG_DIR}/certs
+chmod -R 400 ${TARGET_DIR}${CONFIG_DIR}/certs/*
+
 find ${TARGET_DIR} -type d -exec chmod 750 {} \;
 find ${TARGET_DIR} -type f -perm 644 -exec chmod 640 {} \;
 find ${TARGET_DIR} -type f -perm 664 -exec chmod 660 {} \;

--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -14,23 +14,17 @@ ARG S6_VERSION="v2.2.0.3"
 RUN yum install curl-minimal xz gnupg tar gzip openssl findutils procps -y &&\
     yum clean all
 
-COPY config/check_repository.sh /
-COPY config/filebeat_module.sh /
-COPY config/permanent_data.env config/permanent_data.sh /
+COPY --chmod=755 config/check_repository.sh /
+COPY --chmod=755 config/filebeat_module.sh /
+COPY --chmod=755 config/permanent_data.env config/permanent_data.sh /
+COPY --chmod=755 config/s6-overlay-install.sh /
 
-RUN chmod 775 /check_repository.sh
 RUN source /check_repository.sh
-
 RUN yum install wazuh-manager-${WAZUH_VERSION}-${WAZUH_TAG_REVISION} -y && \
     yum clean all && \
-    chmod 775 /filebeat_module.sh && \
     source /filebeat_module.sh && \
-    rm /filebeat_module.sh && \
-    curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-amd64.tar.gz \
-    -o /tmp/s6-overlay-amd64.tar.gz && \
-    tar xzf /tmp/s6-overlay-amd64.tar.gz -C / --exclude="./bin" && \
-    tar xzf /tmp/s6-overlay-amd64.tar.gz -C /usr ./bin && \
-    rm  /tmp/s6-overlay-amd64.tar.gz
+    rm /filebeat_module.sh
+RUN /s6-overlay-install.sh && rm /s6-overlay-install.sh
 
 COPY config/etc/ /etc/
 COPY --chown=root:wazuh config/create_user.py /var/ossec/framework/scripts/create_user.py

--- a/build-docker-images/wazuh-manager/config/filebeat_module.sh
+++ b/build-docker-images/wazuh-manager/config/filebeat_module.sh
@@ -20,6 +20,16 @@ elif [ "$MAJOR_BUILD" -eq "$MAJOR_CURRENT" ]; then
   fi
 fi
 
-curl -L -O https://artifacts.elastic.co/downloads/beats/filebeat/${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm &&\
-yum install -y ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm && rm -f ${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm && \
+function getArchBasedFilebeat() {
+  case $(arch) in
+    'aarch64' | 'arm64') echo "${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-aarch64.rpm"    ;;
+    'x86_64'  | 'amd64') echo "${FILEBEAT_CHANNEL}-${FILEBEAT_VERSION}-x86_64.rpm"     ;;
+    *)
+      echo "Architecture $(arch) not supported" >> /dev/stderr;
+      exit 1;
+    ;;
+  esac
+}
+
+yum install -y "https://artifacts.elastic.co/downloads/beats/filebeat/$(getArchBasedFilebeat)"
 curl -s https://${REPOSITORY}/filebeat/${WAZUH_FILEBEAT_MODULE} | tar -xvz -C /usr/share/filebeat/module

--- a/build-docker-images/wazuh-manager/config/s6-overlay-install.sh
+++ b/build-docker-images/wazuh-manager/config/s6-overlay-install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+function getArchBasedS6Version() {
+  case $(arch) in
+    'aarch64' | 'arm64') echo "s6-overlay-aarch64.tar.gz"   ;;
+    'x86_64'  | 'amd64') echo "s6-overlay-amd64.tar.gz"     ;;
+    *)
+      echo "Architecture $(arch) not supported" >> /dev/stderr;
+      exit 1;
+    ;;
+  esac
+}
+
+S6_FILE=$(getArchBasedS6Version);
+curl -fsLo "/tmp/${S6_FILE}" "https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/${S6_FILE}";
+tar xzf "/tmp/${S6_FILE}" -C / --exclude="./bin";
+tar xzf "/tmp/${S6_FILE}" -C /usr ./bin;
+rm "/tmp/${S6_FILE}";


### PR DESCRIPTION
Hello Wazuh Community,

In response to issue https://github.com/wazuh/wazuh-docker/issues/923 , I have successfully added ARM64 support to the Wazuh Docker images.

Implementation Summary
- Wazuh Indexer: I deleted the pre-included x86_64 Java binaries and replaced them with build arch-compatible version.
- Wazuh Dashboards: Similarly, I replaced the NodeJS binaries with versions compatible with arch.
- Wazuh Manager(Filebeat): Similarly, I replaced the Filebeat install package with versions compatible with arch.

The main challenge was the incompatibility of pre-built binaries for the ARM64 architecture. By addressing this, I also managed to resolve numerous vulnerabilities related to the NodeJS and Java versions included in the original packages.
