### PR TITLE
Revert create_user.py script deletion

### DIFF
--- a/build-docker-images/wazuh-manager/config/etc/cont-init.d/2-manager
+++ b/build-docker-images/wazuh-manager/config/etc/cont-init.d/2-manager
@@ -93,7 +93,6 @@ EOF
     if /var/ossec/framework/python/bin/python3  /var/ossec/framework/scripts/create_user.py; then
       # remove json if exit code is 0
       rm /var/ossec/api/configuration/admin.json
-      rm /var/ossec/framework/scripts/create_user.py
     else
       echored "There was an error configuring the API user"
       # terminate container to avoid unpredictable behavior


### PR DESCRIPTION
## Description
This PR revert issue https://github.com/wazuh/internal-devel-requests/issues/513 because the` create_user.py ` script is needed when the Wazuh manager container is restarted.
