### PR TITLE
Revert Wazuh images to 4.9.1 version

### DIFF
--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   wazuh.master:
-    image: wazuh/wazuh-manager:4.9.1-rc2
+    image: wazuh/wazuh-manager:4.9.1
     hostname: wazuh.master
     restart: always
     ulimits:
@@ -45,7 +45,7 @@ services:
       - ./config/wazuh_cluster/wazuh_manager.conf:/wazuh-config-mount/etc/ossec.conf
 
   wazuh.worker:
-    image: wazuh/wazuh-manager:4.9.1-rc2
+    image: wazuh/wazuh-manager:4.9.1
     hostname: wazuh.worker
     restart: always
     ulimits:
@@ -81,7 +81,7 @@ services:
       - ./config/wazuh_cluster/wazuh_worker.conf:/wazuh-config-mount/etc/ossec.conf
 
   wazuh1.indexer:
-    image: wazuh/wazuh-indexer:4.9.1-rc2
+    image: wazuh/wazuh-indexer:4.9.1
     hostname: wazuh1.indexer
     restart: always
     ports:
@@ -107,7 +107,7 @@ services:
       - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
 
   wazuh2.indexer:
-    image: wazuh/wazuh-indexer:4.9.1-rc2
+    image: wazuh/wazuh-indexer:4.9.1
     hostname: wazuh2.indexer
     restart: always
     environment:
@@ -129,7 +129,7 @@ services:
       - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
 
   wazuh3.indexer:
-    image: wazuh/wazuh-indexer:4.9.1-rc2
+    image: wazuh/wazuh-indexer:4.9.1
     hostname: wazuh3.indexer
     restart: always
     environment:
@@ -151,7 +151,7 @@ services:
       - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:4.9.1-rc2
+    image: wazuh/wazuh-dashboard:4.9.1
     hostname: wazuh.dashboard
     restart: always
     ports:

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 
 services:
   wazuh.manager:
-    image: wazuh/wazuh-manager:4.9.1-rc2
+    image: wazuh/wazuh-manager:4.9.1
     hostname: wazuh.manager
     restart: always
     ulimits:
@@ -46,7 +46,7 @@ services:
       - ./config/wazuh_cluster/wazuh_manager.conf:/wazuh-config-mount/etc/ossec.conf
 
   wazuh.indexer:
-    image: wazuh/wazuh-indexer:4.9.1-rc2
+    image: wazuh/wazuh-indexer:4.9.1
     hostname: wazuh.indexer
     restart: always
     ports:
@@ -71,7 +71,7 @@ services:
       - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/opensearch-security/internal_users.yml
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:4.9.1-rc2
+    image: wazuh/wazuh-dashboard:4.9.1
     hostname: wazuh.dashboard
     restart: always
     ports:


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-docker/issues/1547

Revert Wazuh docker image to 4.9.1 version