### PR TITLE
Remove deprecated attribute `version` in `docker-compose.yml`

### DIFF
--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -1,5 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3.7'
 
 services:
   wazuh.master:

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -1,5 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3.7'
 
 services:
   wazuh.manager:


### PR DESCRIPTION
## Overview

In `docker-compose.yml` files we used to specify a `version` attribute, but nowadays is deprecated and no longer used. There's a warning message when using `docker-compose.yml` file with `version` attribute specified. Here's the warning message:

```txt
$ docker compose ps
WARN[0000] /dev/wazuh-docker/single-node/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## Official Resources

The [official docker documentation](https://docs.docker.com/reference/compose-file/version-and-name/) said the following about the version attribute.

> The top-level version property is defined by the Compose Specification for backward compatibility. It is only informative and you'll receive a warning message that it is obsolete if used.

## The Modified Files

- `single-node/docker-compose.yml`
- `multi-node/docker-compose.yml`

## What did I modify

I removed the `version` attribute from both  **single-node/docker-compose.yml** and **multi-node/docker-compose.yml** files.