### PR TITLE
build-images.sh referencing wrong directory

### DIFF
--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -71,7 +71,7 @@ build() {
     echo WAZUH_UI_REVISION=$WAZUH_UI_REVISION >> .env
 
     docker-compose -f build-docker-images/build-images.yml --env-file .env build --no-cache
-    docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/wazuh-cert-tool//
+    docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/wazuh-cert-tool/
 
     return 0
 }

--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -14,7 +14,7 @@ IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
 
 WAZUH_IMAGE_VERSION="5.0.0"
 WAZUH_TAG_REVISION="1"
-WAZUH_DEV_STAGE=""
+WAZUH_DEV_STAGE="1"
 FILEBEAT_MODULE_VERSION="0.4"
 
 # -----------------------------------------------------------------------------

--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -71,7 +71,7 @@ build() {
     echo WAZUH_UI_REVISION=$WAZUH_UI_REVISION >> .env
 
     docker-compose -f build-docker-images/build-images.yml --env-file .env build --no-cache
-    docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/wazuh-cert-tool/
+    docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/wazuh-cert-tool//
 
     return 0
 }

--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -14,7 +14,7 @@ IMAGE_VERSION=${WAZUH_IMAGE_VERSION}
 
 WAZUH_IMAGE_VERSION="5.0.0"
 WAZUH_TAG_REVISION="1"
-WAZUH_DEV_STAGE="1"
+WAZUH_DEV_STAGE=""
 FILEBEAT_MODULE_VERSION="0.4"
 
 # -----------------------------------------------------------------------------

--- a/build-docker-images/build-images.sh
+++ b/build-docker-images/build-images.sh
@@ -71,7 +71,7 @@ build() {
     echo WAZUH_UI_REVISION=$WAZUH_UI_REVISION >> .env
 
     docker-compose -f build-docker-images/build-images.yml --env-file .env build --no-cache
-    docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/cert-tool-image/
+    docker build -t wazuh/wazuh-cert-tool:$WAZUH_IMAGE_VERSION build-docker-images/wazuh-cert-tool//
 
     return 0
 }


### PR DESCRIPTION
`build-docker-images/build-images.sh` is referencing a directory called `build-docker-images/cert-tool-image/`
However, this directory does not exist. Changing this to  `build-docker-images/wazuh-cert-tool/` fixes the problem.