### PR TITLE
Remove default docker reference version from workflow

### DIFF
--- a/.github/workflows/Procedure_push_docker_images.yml
+++ b/.github/workflows/Procedure_push_docker_images.yml
@@ -10,7 +10,6 @@ on:
         required: true
       docker_reference:
         description: 'wazuh-docker reference'
-        default: 'v4.13.0'
         required: true
       products:
         description: 'Comma-separated list of the image names to build and push'
@@ -47,7 +46,6 @@ on:
         type: string
       docker_reference:
         description: 'wazuh-docker reference'
-        default: 'v4.13.0'
         required: false
         type: string
       products:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
+- Remove default docker reference version from workflow ([#1761](https://github.com/wazuh/wazuh-docker/pull/1761))
 - Remove 'stable' branch ocurrencies ([#1757](https://github.com/wazuh/wazuh-docker/pull/1757))
 
 ## [4.12.0]


### PR DESCRIPTION
# Description

The changes included in this PR aim to remove the default values of variables referencing the Wazuh-docker repository.

## Related issue

- https://github.com/wazuh/internal-devel-requests/issues/2137