### PR TITLE
fix(entrypoint.sh): correct HTTP header parsing for cert tool check

### DIFF
--- a/build-docker-images/wazuh-cert-tool/config/entrypoint.sh
+++ b/build-docker-images/wazuh-cert-tool/config/entrypoint.sh
@@ -12,8 +12,8 @@ PACKAGES_URL=https://packages.wazuh.com/5.0/
 PACKAGES_DEV_URL=https://packages-dev.wazuh.com/5.0/
 
 ## Check if the cert tool exists in S3 buckets
-CERT_TOOL_PACKAGES=$(curl --silent -I $PACKAGES_URL$CERT_TOOL | grep -E "^HTTP" | awk  '{print $2}')
-CERT_TOOL_PACKAGES_DEV=$(curl --silent -I $PACKAGES_DEV_URL$CERT_TOOL | grep -E "^HTTP" | awk  '{print $2}')
+CERT_TOOL_PACKAGES=$(curl --silent -I $PACKAGES_URL$CERT_TOOL | grep -E "^HTTP" | tail -n-1  | awk  '{print $2}')
+CERT_TOOL_PACKAGES_DEV=$(curl --silent -I $PACKAGES_DEV_URL$CERT_TOOL | grep -E "^HTTP" | tail -n-1  | awk  '{print $2}')
 
 ## If cert tool exists in some bucket, download it, if not exit 1
 if [ "$CERT_TOOL_PACKAGES" = "200" ]; then


### PR DESCRIPTION
Use tail to ensure the last HTTP status code is retrieved for cert tool existence verification in S3 buckets. This is required when using an HTTPS proxy with the container.
The curl behind a proxy will looks like this:

> HTTP/1.1 200 Connection established
> 
> HTTP/2 200
> content-type: text/x-sh
> content-length: 36475
> ...
> 