### PR TITLE
fix(docker): remove obsolete version attribute from docker-compose.yml (#1805)

### DIFF
--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -1,5 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3.7'
 
 services:
   wazuh.master:

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -1,5 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3.7'
 
 services:
   wazuh.manager:


### PR DESCRIPTION
## Summary

This PR removes the obsolete `version` attribute from the `docker-compose.yml` file in the Wazuh Docker repository both single and Multi Node Deployment . As of Docker Compose v1.27.0 and later, the `version` field is deprecated and ignored. Removing it helps prevent confusion and silences related warnings.

## Details

- Removed: `version: '3.8'` from `docker-compose.yml`.
- Verified configuration using:

  ```bash
  docker-compose config
  docker-compose up 

> 
both singleNode and MultiNode work with out any error


## Validation

- Tested successfully using:
-- Docker version 28.1.1
-- Docker Compose version v2.35.1

✅ I Ran `docker-compose config` with no errors or warnings  
✅ All services start correctly with the updated configuration