### PR TITLE
Add filebeat config file in the `PERMANENT_DATA_EXCP` list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Add filebeat config file in the PERMANENT_DATA_EXCP list ([#1898](https://github.com/wazuh/wazuh-docker/pull/1898))
 - Change validation of existing certs tool in S3 buckets ([#1880](https://github.com/wazuh/wazuh-docker/pull/1880))
 
 ### Fixed

--- a/build-docker-images/wazuh-manager/config/permanent_data.env
+++ b/build-docker-images/wazuh-manager/config/permanent_data.env
@@ -100,6 +100,7 @@ PERMANENT_DATA_EXCP[((i++))]="/var/ossec/wodles/gcloud/pubsub/subscriber.py"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/etc/lists/malicious-ioc/malicious-ip"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/etc/lists/malicious-ioc/malicious-domains"
 PERMANENT_DATA_EXCP[((i++))]="/var/ossec/etc/lists/malicious-ioc/malware-hashes"
+PERMANENT_DATA_EXCP[((i++))]="/etc/filebeat/filebeat.yml"
 export PERMANENT_DATA_EXCP
 
 # Files mounted in a volume that should be deleted


### PR DESCRIPTION
# Description

When upgrading between different Wazuh images, the `/etc/filebeat/` path was included in the list of permanent data, so the file `/etc/filebeat/filebeat.yml` was never updated.
This PR changes that behavior by adding this file to the `PERMANENT_DATA_EXCP` list so that when upgrading to a new version, the file is updated as well.

## Testing 🧪 

You can see how the upgrade from one version to another was tested with these changes in this comment:

- https://github.com/wazuh/wazuh-docker/issues/1563#issuecomment-2991037102