### PR TITLE
Delete services statement in wazuh agent deployment

### DIFF
--- a/wazuh-agent/docker-compose.yml
+++ b/wazuh-agent/docker-compose.yml
@@ -1,6 +1,4 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
-version: '3.7'
-
 services:
   wazuh.agent:
     image: wazuh/wazuh-agent:4.13.0


### PR DESCRIPTION
Related issue #1922 
This PR removes the `version` statement in the docker-compose.yml file of the Wazuh agent