### PR TITLE
Update Dockerfile to copy `opensearch-security` files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Update Dockerfile to copy opensearch-security files ([#1928](https://github.com/wazuh/wazuh-docker/pull/1928))
 
 ### Deleted
 

--- a/build-docker-images/wazuh-indexer/Dockerfile
+++ b/build-docker-images/wazuh-indexer/Dockerfile
@@ -68,6 +68,7 @@ RUN chown 1000:1000 /*.sh
 
 COPY --from=builder --chown=1000:1000 /usr/share/wazuh-indexer /usr/share/wazuh-indexer
 COPY --from=builder --chown=1000:1000 /etc/wazuh-indexer /usr/share/wazuh-indexer
+COPY --from=builder --chown=1000:1000 /debian/wazuh-indexer/usr/share/wazuh-indexer /usr/share/wazuh-indexer
 COPY --from=builder --chown=0:0 /debian/wazuh-indexer/usr/lib/systemd /usr/lib/systemd
 COPY --from=builder --chown=0:0 /debian/wazuh-indexer/usr/lib/sysctl.d /usr/lib/sysctl.d
 COPY --from=builder --chown=0:0 /debian/wazuh-indexer/usr/lib/tmpfiles.d /usr/lib/tmpfiles.d


### PR DESCRIPTION
### Related

- https://github.com/wazuh/wazuh-docker/issues/1924

### Testt

- https://github.com/wazuh/wazuh-docker/issues/1924#issuecomment-3050214739