### PR TITLE
add python3-requests for wazuh external integration

### DIFF
--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -23,6 +23,7 @@ RUN source /check_repository.sh
 
 RUN yum install wazuh-manager-${WAZUH_VERSION}-${WAZUH_TAG_REVISION} -y && \
     yum clean all && \
+    yum install python3-requests -y && \
     chmod 775 /filebeat_module.sh && \
     source /filebeat_module.sh && \
     rm /filebeat_module.sh && \


### PR DESCRIPTION
Some integrations like Slack, Telegram, Jira require the python3-requests module to send notifications.
However, this module is not included in the wazuh-manager image.