### PR TITLE
Add custom Nginx entrypoint to wait for Wazuh upstreams before start

### DIFF
--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -187,6 +187,15 @@ services:
       - wazuh.dashboard:wazuh.dashboard
     volumes:
       - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx-entrypoint-check.sh:/nginx-entrypoint-check.sh
+    command:
+      - /bin/sh
+      - -c
+      - |
+        apt update && \
+        apt install -y netcat-openbsd && \
+        chmod +x /nginx-entrypoint-check.sh && \
+        /nginx-entrypoint-check.sh
 
 volumes:
   master-wazuh-api-configuration:

--- a/multi-node/nginx-entrypoint-check.sh
+++ b/multi-node/nginx-entrypoint-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+wait_for_upstream() {
+  host=$1
+  port=$2
+
+  echo "Waiting for $host:$port..."
+  while ! nc -z "$host" "$port"; do
+    echo "Still waiting for $host:$port..."
+    sleep 1
+  done
+  echo "$host:$port is available!"
+}
+
+wait_for_upstream wazuh-master 1514
+wait_for_upstream wazuh-worker 1514
+
+echo "All upstreams are reachable, starting native entrypoint..."
+
+exec /docker-entrypoint.sh nginx -g "daemon off;"


### PR DESCRIPTION
This PR introduces a custom Nginx startup script that ensures Wazuh upstream nodes are reachable before Nginx begins serving traffic.
The change improves reliability during multi-node deployments, avoiding potential startup race conditions between Nginx and Wazuh services.

### Changes
Added `nginx-entrypoint-check.sh` script:
Waits for connectivity to:
`wazuh-master:1514`
`wazuh-worker:1514`
Starts Nginx only after both are reachable.
Updated multi-node/docker-compose.yml:
Mounted the script into the Nginx container.
Added runtime installation of netcat-openbsd (required for network checks).
Adjusted container command to execute the custom entrypoint.

### Future Improvements
I can move the netcat-openbsd installation to a build-time step in a custom Nginx image for faster and more deterministic startup. Additionally, replacing apt update at runtime with a prebuilt image for production use.