### PR TITLE
Fix invalid Docker image tags (5.0.0 → 4.14.0)

### DIFF
--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
 services:
   wazuh.manager:
-    image: wazuh/wazuh-manager:5.0.0
+    image: wazuh/wazuh-manager:4.14.0
     hostname: wazuh.manager
     restart: always
     ulimits:
@@ -42,7 +42,7 @@ services:
       - ./config/wazuh_cluster/wazuh_manager.conf:/wazuh-config-mount/etc/ossec.conf
 
   wazuh.indexer:
-    image: wazuh/wazuh-indexer:5.0.0
+    image: wazuh/wazuh-indexer:4.14.0
     hostname: wazuh.indexer
     restart: always
     ports:
@@ -67,7 +67,7 @@ services:
       - ./config/wazuh_indexer/internal_users.yml:/usr/share/wazuh-indexer/config/opensearch-security/internal_users.yml
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:5.0.0
+    image: wazuh/wazuh-dashboard:4.14.0
     hostname: wazuh.dashboard
     restart: always
     ports:


### PR DESCRIPTION
The current docker-compose.yml files in this repository for single-node reference Docker images tagged 5.0.0, for example:

```yaml
image: wazuh/wazuh-manager:5.0.0
image: wazuh/wazuh-indexer:5.0.0
image: wazuh/wazuh-dashboard:5.0.0
```

However, these image tags do not exist on Docker Hub, which causes deployment failures with the following error:

```sh
Error manifest for wazuh/wazuh-indexer:5.0.0 not found: manifest unknown
```
Docker Hub repository:
https://hub.docker.com/r/wazuh/wazuh-indexer/tags
https://hub.docker.com/r/wazuh/wazuh-dashboard/tags
https://hub.docker.com/r/wazuh/wazuh-manager/tags

Proposed Changes

Updated all image tags to the latest available stable release: 4.14.0.
```yaml
image: wazuh/wazuh-manager:4.14.0
image: wazuh/wazuh-indexer:4.14.0
image: wazuh/wazuh-dashboard:4.14.0
```
Steps to Reproduce

1. Clone the repository.

2. Navigate to the single-node directory.

3.  Run `sudo sysctl -w vm.max_map_count=262144`

4. Run `docker compose up -d`.

Observe that the wazuh.indexer and other services fail with a “manifest unknown” error.

---
Verification

After changing the version to 4.14.0:

The stack builds and runs successfully.

Dashboard, Manager, and Indexer communicate correctly.


Verified latest version available as of today: 4.14.0.