### PR TITLE
Fix WAZUH_AGENT_GROUPS placeholder in wazuh-agent image

### DIFF
--- a/build-docker-images/wazuh-agent/Dockerfile
+++ b/build-docker-images/wazuh-agent/Dockerfile
@@ -23,6 +23,7 @@ RUN URL_VAR="wazuh_agent_${TARGETARCH}_rpm" && \
     rm -rf /wazuh-agent.rpm && \
     dnf clean all && \
     sed -i '/<authorization_pass_path>/d' /var/ossec/etc/ossec.conf && \
+    sed -i '/<agent_name>/a\      <groups>CHANGE_AGENT_GROUPS</groups>' /var/ossec/etc/ossec.conf && \
     S6_ARCH="amd64" && \
     if [ "${TARGETARCH}" = "arm64" ]; then S6_ARCH="aarch64"; fi && \
     curl --fail --silent -L https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${S6_ARCH}.tar.gz \


### PR DESCRIPTION
# Summary

This PR fixes `WAZUH_AGENT_GROUPS` handling in the Wazuh agent Docker image.

The container init script already supports `WAZUH_AGENT_GROUPS` and attempts to replace:

```xml
<groups>CHANGE_AGENT_GROUPS</groups>
```
in `/var/ossec/etc/ossec.conf`.

However, the Docker image build process did not ensure that this placeholder existed in the packaged ossec.conf, so the replacement never happened and the final runtime configuration omitted the group.

## Changes

Insert `<groups>CHANGE_AGENT_GROUPS</groups>` after `<agent_name>` in `/var/ossec/etc/ossec.conf` during the image build process.

## Result

When `WAZUH_AGENT_GROUPS` is set, the generated ossec.conf now correctly includes the `<groups>` entry under `<enrollment>`.

### Observed behavior

In the running container:

`WAZUH_AGENT_GROUPS` is present in the environment

`/etc/cont-init.d/0-wazuh-init` contains the replacement logic for `<groups>CHANGE_AGENT_GROUPS</groups>`

`/var/ossec/etc/ossec.conf` does not contain that placeholder by default

As a result, the replacement never occurs and the agent is enrolled without the configured group.
