### PR TITLE
Adapt bumper workflows to change main branch

### DIFF
--- a/.github/workflows/5_bumper_repository.yml
+++ b/.github/workflows/5_bumper_repository.yml
@@ -1,4 +1,4 @@
-name: Repository bumper 4.x
+name: Repository bumper 5.x
 run-name: Bump ${{ github.ref_name }} (${{ inputs.id }})
 
 on:
@@ -14,6 +14,11 @@ on:
         default: ''
         required: false
         type: string
+      set_as_main:
+        description: "Enable main branch mode: bump version values only, keep branch references pointing to main"
+        required: false
+        type: boolean
+        default: false
       issue-link:
         description: 'Issue link in format https://github.com/wazuh/<REPO>/issues/<ISSUE-NUMBER>'
         required: true
@@ -25,7 +30,7 @@ on:
 
 jobs:
   bump:
-    name: Repository bumper 4.x
+    name: Repository bumper 5.x
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -81,11 +86,17 @@ jobs:
           version=${{ env.VERSION }}
           stage=${{ env.STAGE }}
 
+          set_as_main=${{ inputs.set_as_main }}
+
+          if [[ "$set_as_main" == "true" ]]; then
+            script_params="--set-as-main"
+          fi
+
           # Both version and stage provided
           if [[ -n "$version" && -n "$stage" ]]; then
-            script_params="--version ${version} --stage ${stage}"
+            script_params+=" --version ${version} --stage ${stage}"
           elif [[ -z "$version" && -n "$stage" ]]; then
-            script_params="--stage ${stage}"
+            script_params+=" --stage ${stage}"
           fi
 
           issue_number=$(echo "${{ inputs.issue-link }}" | awk -F'/' '{print $NF}')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Adapt bumper workflows to change main branch ([#2294](https://github.com/wazuh/wazuh-docker/pull/2294))
 - Delete all API user and password references and Wazuh agent references ([#2289](https://github.com/wazuh/wazuh-docker/pull/2289))
 - Create certificate directory with default user and group ([#2287](https://github.com/wazuh/wazuh-docker/pull/2287))
 - Standarize Artifact URL keys ([#2286](https://github.com/wazuh/wazuh-docker/pull/2286))


### PR DESCRIPTION
Related Issue #2276 

The changes in the workflows are merged to test the changes made in branch [change/2276-set_as_main-option](https://github.com/wazuh/wazuh-docker/tree/change/2276-set_as_main-option)