### PR TITLE
Add Wazuh indexer engine start on entrypoint

### DIFF
--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -442,6 +442,7 @@ jobs:
         if [ -f "$TARGET_FILE" ]; then
           echo "Updating registry in $TARGET_FILE to: ${{ env.WAZUH_REGISTRY }}"
           sed -i "s|wazuh/wazuh-|${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-|g" "$TARGET_FILE"
+          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
         else
           echo "File $TARGET_FILE not found"
           exit 1

--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -76,7 +76,7 @@ jobs:
       uses: aws-actions/amazon-ecr-login@v2
 
     - name: Execute Goss tests (wazuh-manager)
-      run: dgoss run ${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-manager:${{ env.WAZUH_IMAGE_VERSION }}
+      run: dgoss run ${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-manager:${{ env.WAZUH_IMAGE_VERSION }}-latest
       env:
         GOSS_SLEEP: 30
         GOSS_FILE: .github/.goss.yaml
@@ -162,6 +162,7 @@ jobs:
         if [ -f "$TARGET_FILE" ]; then
           echo "Updating registry in $TARGET_FILE to: ${{ env.WAZUH_REGISTRY }}"
           sed -i "s|wazuh/wazuh-|${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-|g" "$TARGET_FILE"
+          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
         else
           echo "File $TARGET_FILE not found"
           exit 1

--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -285,6 +285,7 @@ jobs:
         if [ -f "$TARGET_FILE" ]; then
           echo "Updating registry in $TARGET_FILE to: ${{ env.WAZUH_REGISTRY }}"
           sed -i "s|wazuh/wazuh-|${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-|g" "$TARGET_FILE"
+          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_IMAGE_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
         else
           echo "File $TARGET_FILE not found"
           exit 1
@@ -575,6 +576,7 @@ jobs:
         if [ -f "$TARGET_FILE" ]; then
           echo "Updating registry in $TARGET_FILE to: ${{ env.WAZUH_REGISTRY }}"
           sed -i "s|wazuh/wazuh-|${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-|g" "$TARGET_FILE"
+          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_IMAGE_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
         else
           echo "File $TARGET_FILE not found"
           exit 1

--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -162,7 +162,7 @@ jobs:
         if [ -f "$TARGET_FILE" ]; then
           echo "Updating registry in $TARGET_FILE to: ${{ env.WAZUH_REGISTRY }}"
           sed -i "s|wazuh/wazuh-|${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-|g" "$TARGET_FILE"
-          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
+          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_IMAGE_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
         else
           echo "File $TARGET_FILE not found"
           exit 1
@@ -442,7 +442,7 @@ jobs:
         if [ -f "$TARGET_FILE" ]; then
           echo "Updating registry in $TARGET_FILE to: ${{ env.WAZUH_REGISTRY }}"
           sed -i "s|wazuh/wazuh-|${{ env.WAZUH_REGISTRY }}/wazuh/wazuh-|g" "$TARGET_FILE"
-          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
+          sed -i "s/\(.*wazuh\/wazuh-.*:\)${{ env.WAZUH_IMAGE_VERSION }}/\1${{ env.WAZUH_IMAGE_VERSION }}-latest/g" "$TARGET_FILE"
         else
           echo "File $TARGET_FILE not found"
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Add Wazuh indexer engine start on entrypoint ([#2390](https://github.com/wazuh/wazuh-docker/pull/2390))
 - Image build process update ([#2358](https://github.com/wazuh/wazuh-docker/pull/2358))
 - Add new path on artifact_urls file ([#2344](https://github.com/wazuh/wazuh-docker/pull/2344))
 - Presigned URLs generation enhancement ([#2346](https://github.com/wazuh/wazuh-docker/pull/2346))

--- a/build-docker-images/wazuh-indexer/Dockerfile
+++ b/build-docker-images/wazuh-indexer/Dockerfile
@@ -32,7 +32,8 @@ FROM amazonlinux:2023
 ENV USER="wazuh-indexer" \
     GROUP="wazuh-indexer" \
     NAME="wazuh-indexer" \
-    INSTALL_DIR="/usr/share/wazuh-indexer"
+    INSTALL_DIR="/usr/share/wazuh-indexer" 
+ENV ENGINE_DIR="$INSTALL_DIR/engine"
 
 
 COPY config/entrypoint.sh /
@@ -63,7 +64,14 @@ COPY --from=builder --chown=1000:1000 $INSTALL_DIR $INSTALL_DIR
 RUN chmod 700 $INSTALL_DIR && \
     chmod 700 $INSTALL_DIR/config && \
     chmod 600 $INSTALL_DIR/config/jvm.options && \
-    chmod 600 $INSTALL_DIR/config/opensearch.yml
+    chmod 600 $INSTALL_DIR/config/opensearch.yml && \
+    if [ -d "$ENGINE_DIR" ]; then \
+    find "$ENGINE_DIR" -type d -exec chmod 750 {} + && \
+    find "$ENGINE_DIR" -type f -exec chmod 640 {} + && \
+    { [ -f "$ENGINE_DIR/run_engine.sh" ] && chmod 750 "$ENGINE_DIR/run_engine.sh" || true; } && \
+    { [ -f "$ENGINE_DIR/bin/wazuh-engine" ] && chmod 750 "$ENGINE_DIR/bin/wazuh-engine" || true; } && \
+    { [ -d "$ENGINE_DIR/sockets" ] && chmod 777 "$ENGINE_DIR/sockets" || true; }; \
+    fi
 
 USER wazuh-indexer
 WORKDIR $INSTALL_DIR

--- a/build-docker-images/wazuh-indexer/config/entrypoint.sh
+++ b/build-docker-images/wazuh-indexer/config/entrypoint.sh
@@ -58,6 +58,12 @@ function runOpensearch {
         fi
     done < <(env)
 
+    # Start Wazuh Engine
+    if [ -x "$OPENSEARCH_HOME/engine/run_engine.sh" ]; then
+        nohup "$OPENSEARCH_HOME/engine/run_engine.sh" > /dev/null 2>&1 &
+        echo $! > /run/wazuh-indexer/wazuh-engine.pid
+    fi
+
     # Start opensearch
     exec "$@" "${opensearch_opts[@]}"
 

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
 services:
   wazuh.manager:
-    image: wazuh/wazuh-manager:5.0.0-beta1-latest
+    image: wazuh/wazuh-manager:5.0.0
     hostname: wazuh.manager
     container_name: single-node-wazuh.manager
     restart: always
@@ -43,7 +43,7 @@ services:
       - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
 
   wazuh.indexer:
-    image: wazuh/wazuh-indexer:5.0.0-beta1-latest
+    image: wazuh/wazuh-indexer:5.0.0
     hostname: wazuh.indexer
     container_name: single-node-wazuh.indexer
     restart: always
@@ -80,7 +80,7 @@ services:
       - ./config/wazuh_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:5.0.0-beta1-latest
+    image: wazuh/wazuh-dashboard:5.0.0
     hostname: wazuh.dashboard
     container_name: single-node-wazuh.dashboard
     restart: always

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
 services:
   wazuh.manager:
-    image: wazuh/wazuh-manager:5.0.0
+    image: wazuh/wazuh-manager:5.0.0-beta1-latest
     hostname: wazuh.manager
     container_name: single-node-wazuh.manager
     restart: always
@@ -43,7 +43,7 @@ services:
       - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
 
   wazuh.indexer:
-    image: wazuh/wazuh-indexer:5.0.0
+    image: wazuh/wazuh-indexer:5.0.0-beta1-latest
     hostname: wazuh.indexer
     container_name: single-node-wazuh.indexer
     restart: always
@@ -80,7 +80,7 @@ services:
       - ./config/wazuh_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:5.0.0
+    image: wazuh/wazuh-dashboard:5.0.0-beta1-latest
     hostname: wazuh.dashboard
     container_name: single-node-wazuh.dashboard
     restart: always


### PR DESCRIPTION
Add Wazuh indexer engine start on entrypoint

## Test

$ docker exec -it single-node-wazuh.indexer bash
bash-5.2$ ls -ltr | grep engine
drwxr-x---.  1 wazuh-indexer wazuh-indexer     33 May 11 18:16 engine
bash-5.2$ ls -ltr engine/
total 12
-rwxr-x---. 1 wazuh-indexer wazuh-indexer 2005 May 11 17:05 run_engine.sh
-rw-r-----. 1 wazuh-indexer wazuh-indexer 4127 May 11 17:05 README.md
drwxr-x---. 1 wazuh-indexer wazuh-indexer   37 May 11 18:16 bin
drwxr-x---. 1 wazuh-indexer wazuh-indexer   59 May 11 18:16 schemas
drwxr-x---. 1 wazuh-indexer wazuh-indexer   19 May 11 18:16 logs
drwxrwxrwx. 1 wazuh-indexer wazuh-indexer   29 May 11 18:28 sockets
drwxr-x---. 1 wazuh-indexer wazuh-indexer   96 May 11 18:31 data
bash-5.2$ 

<img width="1911" height="881" alt="image" src="https://github.com/user-attachments/assets/d4accbf7-a433-4030-84d8-75b3284b059c" />
