### PR TITLE
Forbid pr_check workflow execution in draft PRs

### DIFF
--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -53,7 +53,6 @@ jobs:
       dev: true
 
   Execute-Goss-tests:
-    if: needs.build-images.result != 'skipped'
     needs: [prepare-variables, build-images]
     runs-on: ubuntu-22.04
     env:
@@ -86,7 +85,6 @@ jobs:
 
   check-single-node:
     name: Check single node on ${{ matrix.os }}
-    if: needs.Execute-Goss-tests.result != 'skipped'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -362,7 +360,6 @@ jobs:
 
   check-multi-node:
     name: Check multi node on ${{ matrix.os }}
-    if: needs.Execute-Goss-tests.result != 'skipped'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -4,6 +4,7 @@ permissions:
   id-token: write
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       docker_reference:
@@ -14,6 +15,7 @@ on:
 jobs:
 
   prepare-variables:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     outputs:
       WAZUH_VERSION: ${{ steps.dotenv.outputs.WAZUH_VERSION }}
@@ -51,6 +53,7 @@ jobs:
       dev: true
 
   Execute-Goss-tests:
+    if: needs.build-images.result != 'skipped'
     needs: [prepare-variables, build-images]
     runs-on: ubuntu-22.04
     env:
@@ -83,12 +86,13 @@ jobs:
 
   check-single-node:
     name: Check single node on ${{ matrix.os }}
+    if: needs.Execute-Goss-tests.result != 'skipped'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
       fail-fast: false
-    needs: [prepare-variables, Execute-Goss-tests, build-images]
+    needs: [prepare-variables, Execute-Goss-tests]
     env:
       WAZUH_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.WAZUH_IMAGE_VERSION }}
       WAZUH_MINOR_VERSION: ${{ needs.prepare-variables.outputs.WAZUH_MINOR_VERSION }}
@@ -358,12 +362,13 @@ jobs:
 
   check-multi-node:
     name: Check multi node on ${{ matrix.os }}
+    if: needs.Execute-Goss-tests.result != 'skipped'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-22.04-arm]
       fail-fast: false
-    needs: [prepare-variables, Execute-Goss-tests, build-images]
+    needs: [prepare-variables, Execute-Goss-tests]
     env:
       WAZUH_IMAGE_VERSION: ${{ needs.prepare-variables.outputs.WAZUH_IMAGE_VERSION }}
       WAZUH_MINOR_VERSION: ${{ needs.prepare-variables.outputs.WAZUH_MINOR_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Forbid pr_check workflow execution in draft PRs ([#2399](https://github.com/wazuh/wazuh-docker/pull/2399))
 - Unification of user UID and GID ([#2393](https://github.com/wazuh/wazuh-docker/pull/2393))
 - Add Wazuh indexer engine start on entrypoint ([#2390](https://github.com/wazuh/wazuh-docker/pull/2390))
 - Image build process update ([#2358](https://github.com/wazuh/wazuh-docker/pull/2358))


### PR DESCRIPTION
## Description

The goal of this PR is to prevent the xdrsiem-dev infrastructure management workflow from running on draft pull requests.

To achieve this, the necessary types have been added to the pull_request trigger, notably the ready_for_review type.

A condition has also been added to check whether the PR is in draft status, since the synchronized type in the pull_request trigger triggers whenever a commit is made to a PR, even if it is in draft status.

## Testing 🧪 

<details>
<summary>Draft PRs</summary>

<img width="831" height="612" alt="image" src="https://github.com/user-attachments/assets/980afb0a-4ab0-46e8-86d5-25382bcfd721" />


</details>

<details>
<summary>Open PRs</summary>

<img width="863" height="812" alt="image" src="https://github.com/user-attachments/assets/fd6ea8a4-bb87-414b-bd71-e5d31103e86b" />


</details>
