### PR TITLE
docs(single-node): Loki/Alloy alerts export and analysisd permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# JSON alerts exported for Alloy → Loki (may contain sensitive data)
+single-node/wazuh-alerts-export/
+
 single-node/config/wazuh_indexer_ssl_certs/*.pem
 single-node/config/wazuh_indexer_ssl_certs/*.key
 multi-node/config/wazuh_indexer_ssl_certs/*.pem

--- a/single-node/README.md
+++ b/single-node/README.md
@@ -22,3 +22,21 @@ $ docker compose up -d
 ```
 
 The environment takes about 1 minute to get up (depending on your Docker host) for the first time since Wazuh Indexer must be started for the first time and the indexes and index patterns must be generated.
+
+## Loki / Alloy (optional)
+
+The manager service bind-mounts **`./wazuh-alerts-export`** to **`/var/ossec/logs/alerts`** so `alerts.json` is visible on the host for **Grafana Alloy** in `grafana-loki-alloy` (labeled `job=wazuh` in Loki). That directory is gitignored.
+
+**Permissions (required):** Docker usually creates the host directory as **root**. Inside the container, **`wazuh-analysisd` runs as uid 999** and must create paths such as `logs/alerts/2026/`. If ownership is wrong, `wazuh-analysisd` exits, the Wazuh **API returns 500**, and the dashboard shows errors (for example `getUserPolicies`, `check-stored-api`).
+
+After the directory exists (first `docker compose up` is enough to create it), run:
+
+```bash
+cd single-node
+chmod +x scripts/ensure-alerts-export-perms.sh
+./scripts/ensure-alerts-export-perms.sh   # uses sudo if not already root-owned by 999
+# if the script tells you to run sudo chown, do that, then:
+docker compose restart wazuh.manager
+```
+
+Confirm: `docker exec "$(docker compose ps -q wazuh.manager)" /var/ossec/bin/wazuh-control status` should show **`wazuh-analysisd is running`**.

--- a/single-node/scripts/ensure-alerts-export-perms.sh
+++ b/single-node/scripts/ensure-alerts-export-perms.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Wazuh manager bind-mounts ./wazuh-alerts-export -> /var/ossec/logs/alerts for Alloy/Loki.
+# Docker creates the host directory as root; wazuh-analysisd runs as uid 999 and must
+# create subdirs (e.g. 2026/) under alerts — fix ownership or analysisd stays down and the API returns 500.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIR="${ROOT}/wazuh-alerts-export"
+OWNER="${WAZUH_ALERTS_UID:-999}:${WAZUH_ALERTS_GID:-999}"
+
+mkdir -p "${DIR}"
+if chown -R "${OWNER}" "${DIR}" 2>/dev/null; then
+  echo "OK: ${DIR} -> ${OWNER}"
+  exit 0
+fi
+
+echo "Could not chown ${DIR} (need root). Run:"
+echo "  sudo chown -R ${OWNER} \"${DIR}\""
+echo "Then: cd \"${ROOT}\" && docker compose restart wazuh.manager"
+exit 1


### PR DESCRIPTION
Gitignore wazuh-alerts-export for JSON alerts bound for Alloy. Document uid 999 ownership requirement and add ensure-alerts-export-perms.sh helper.