### PR TITLE
Changed `update_user` function from `wazuh.security` to `wazuh.rbac.orm` module

### DIFF
--- a/.github/.goss.yaml
+++ b/.github/.goss.yaml
@@ -34,20 +34,6 @@ file:
     group: wazuh
     filetype: file
     contains: []
-  /var/ossec/etc/sslmanager.cert:
-    exists: true
-    mode: "0640"
-    owner: root
-    group: root
-    filetype: file
-    contains: []
-  /var/ossec/etc/sslmanager.key:
-    exists: true
-    mode: "0640"
-    owner: root
-    group: root
-    filetype: file
-    contains: []
 package:
   filebeat:
     installed: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Changed update_user function from wazuh.security to wazuh.rbac.orm module ([#2405](https://github.com/wazuh/wazuh-docker/pull/2405))
 - Add wazuh-template.json into permanent data exception ([#1967](https://github.com/wazuh/wazuh-docker/pull/1967))
 
 ### Deleted

--- a/build-docker-images/wazuh-manager/config/create_user.py
+++ b/build-docker-images/wazuh-manager/config/create_user.py
@@ -13,13 +13,12 @@ SPECIAL_CHARS = "@$!%*?&-_"
 
 
 try:
-    from wazuh.rbac.orm import check_database_integrity
+    from wazuh.rbac.orm import check_database_integrity, AuthenticationManager
     from wazuh.security import (
         create_user,
         get_users,
         get_roles,
         set_user_role,
-        update_user,
     )
 except ModuleNotFoundError as e:
     logging.error("No module 'wazuh' found.")
@@ -54,12 +53,11 @@ def disable_user(uid):
     # assure there must be at least one character from each group
     random_pass = random_pass + ''.join([random.choice(chars) for chars in [string.ascii_lowercase, string.digits, string.ascii_uppercase, SPECIAL_CHARS]])
     random_pass = ''.join(random.sample(random_pass,len(random_pass)))
-    update_user(
-        user_id=[
-            str(uid),
-        ],
-        password=random_pass,
-    )
+    with AuthenticationManager() as auth:
+        auth.update_user(
+            user_id=uid,
+            password=random_pass,
+        )
 
 
 if __name__ == "__main__":
@@ -90,12 +88,11 @@ if __name__ == "__main__":
     else:
         # modify an existing user ("wazuh" or "wazuh-wui")
         uid = initial_users[username]
-        update_user(
-            user_id=[
-                str(uid),
-            ],
-            password=password,
-        )
+        with AuthenticationManager() as auth:
+            auth.update_user(
+                user_id=uid,
+                password=password,
+            )
     # disable unused default users
     for def_user in ['wazuh', 'wazuh-wui']:
         if def_user != username:


### PR DESCRIPTION
## Related issue

- https://github.com/wazuh/wazuh-docker/issues/2404

# Description

As described in the related issue, the `wazuh-manager` Docker deployment was falling into a infinite loop.
The `wazuh-manager` container was restarting in loop because it couldn't modify the user credentials.

## What caused the issue

The function from the Wazuh API used to update the users was `update_user` from `wazuh.security` module. This function was modified in [this PR](https://github.com/wazuh/wazuh/pull/35469). Specifically in [this commit](https://github.com/wazuh/wazuh/commit/1a38d11574c6d35a4272e1e7145d55d293e7dda4).

> [!NOTE]
> This change has been done for 5.0 too.

This change caused the deployment of the wazuh-manager container to stop working properly.

## Fix

I found a workaround to fix this behavior. Using the `update_user` function from the `wazuh.rbac.orm` module `AuthenticationManager` class instead, which updates directly without RBAC restrictions.

## Tests

I reconstructed the images with the changes. I deployed the containers and checked their status:

```shellsession
root@ubuntu-jammy:/home/vagrant/wazuh-docker/single-node# docker-compose up -d
[+] Running 18/18
 ⠿ Network single-node_default                   Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh-dashboard-custom"   Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_wodles"             Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh-indexer-data"       Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh-dashboard-config"   Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_integrations"       Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_logs"               Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_api_configuration"  Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_agentless"          Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_var_multigroups"    Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_queue"              Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_active_response"    Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_wazuh_etc"                Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_filebeat_etc"             Created                                                                                                                                                                                                                             0.0s
 ⠿ Volume "single-node_filebeat_var"             Created                                                                                                                                                                                                                             0.0s
 ⠿ Container single-node-wazuh.manager-1         Started                                                                                                                                                                                                                             0.4s
 ⠿ Container single-node-wazuh.indexer-1         Started                                                                                                                                                                                                                             0.3s
 ⠿ Container single-node-wazuh.dashboard-1       Started

root@ubuntu-jammy:/home/vagrant/wazuh-docker/single-node# docker ps -a
CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                                 NAMES
120c5d39285b   wazuh/wazuh-dashboard:4.10.4   "/entrypoint.sh"         17 seconds ago   Up 16 seconds   443/tcp, 0.0.0.0:443->5601/tcp, [::]:443->5601/tcp                                                                                                                    single-node-wazuh.dashboard-1
afe85b46e4ff   wazuh/wazuh-manager:4.10.4     "/init"                  17 seconds ago   Up 17 seconds   0.0.0.0:1514-1515->1514-1515/tcp, [::]:1514-1515->1514-1515/tcp, 0.0.0.0:514->514/udp, [::]:514->514/udp, 0.0.0.0:55000->55000/tcp, [::]:55000->55000/tcp, 1516/tcp   single-node-wazuh.manager-1
e9eac5517f82   wazuh/wazuh-indexer:4.10.4     "/entrypoint.sh open…"   17 seconds ago   Up 17 seconds   0.0.0.0:9200->9200/tcp, [::]:9200->9200/tcp                                                                                                                           single-node-wazuh.indexer-1
root@ubuntu-jammy:/home/vagrant/wazuh-docker/single-node# docker ps -a
CONTAINER ID   IMAGE                          COMMAND                  CREATED          STATUS          PORTS                                                                                                                                                                 NAMES
120c5d39285b   wazuh/wazuh-dashboard:4.10.4   "/entrypoint.sh"         14 minutes ago   Up 14 minutes   443/tcp, 0.0.0.0:443->5601/tcp, [::]:443->5601/tcp                                                                                                                    single-node-wazuh.dashboard-1
afe85b46e4ff   wazuh/wazuh-manager:4.10.4     "/init"                  14 minutes ago   Up 14 minutes   0.0.0.0:1514-1515->1514-1515/tcp, [::]:1514-1515->1514-1515/tcp, 0.0.0.0:514->514/udp, [::]:514->514/udp, 0.0.0.0:55000->55000/tcp, [::]:55000->55000/tcp, 1516/tcp   single-node-wazuh.manager-1
e9eac5517f82   wazuh/wazuh-indexer:4.10.4     "/entrypoint.sh open…"   14 minutes ago   Up 14 minutes   0.0.0.0:9200->9200/tcp, [::]:9200->9200/tcp
```

<img width="2306" height="1307" alt="imagen" src="https://github.com/user-attachments/assets/9f2eae43-c373-4c58-adcd-eab2819175b5" />

