### PR TITLE
Changed `update_user` function from `wazuh.security` to `wazuh.rbac.orm` module

### DIFF
--- a/.github/.goss.yaml
+++ b/.github/.goss.yaml
@@ -34,20 +34,6 @@ file:
     group: wazuh
     filetype: file
     contains: []
-  /var/ossec/etc/sslmanager.cert:
-    exists: true
-    mode: "0640"
-    owner: root
-    group: root
-    filetype: file
-    contains: []
-  /var/ossec/etc/sslmanager.key:
-    exists: true
-    mode: "0640"
-    owner: root
-    group: root
-    filetype: file
-    contains: []
 package:
   filebeat:
     installed: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Changed update_user function from wazuh.security to wazuh.rbac.orm module ([#2406](https://github.com/wazuh/wazuh-docker/pull/2406))
 - GH issue notification fix ([#2312](https://github.com/wazuh/wazuh-docker/pull/2312))
 
 ### Deleted

--- a/build-docker-images/wazuh-manager/config/create_user.py
+++ b/build-docker-images/wazuh-manager/config/create_user.py
@@ -13,13 +13,12 @@ SPECIAL_CHARS = "@$!%*?&-_"
 
 
 try:
-    from wazuh.rbac.orm import check_database_integrity
+    from wazuh.rbac.orm import check_database_integrity, AuthenticationManager
     from wazuh.security import (
         create_user,
         get_users,
         get_roles,
         set_user_role,
-        update_user,
     )
 except ModuleNotFoundError as e:
     logging.error("No module 'wazuh' found.")
@@ -54,12 +53,11 @@ def disable_user(uid):
     # assure there must be at least one character from each group
     random_pass = random_pass + ''.join([random.choice(chars) for chars in [string.ascii_lowercase, string.digits, string.ascii_uppercase, SPECIAL_CHARS]])
     random_pass = ''.join(random.sample(random_pass,len(random_pass)))
-    update_user(
-        user_id=[
-            str(uid),
-        ],
-        password=random_pass,
-    )
+    with AuthenticationManager() as auth:
+        auth.update_user(
+            user_id=uid,
+            password=random_pass,
+        )
 
 
 if __name__ == "__main__":
@@ -90,12 +88,11 @@ if __name__ == "__main__":
     else:
         # modify an existing user ("wazuh" or "wazuh-wui")
         uid = initial_users[username]
-        update_user(
-            user_id=[
-                str(uid),
-            ],
-            password=password,
-        )
+        with AuthenticationManager() as auth:
+            auth.update_user(
+                user_id=uid,
+                password=password,
+            )
     # disable unused default users
     for def_user in ['wazuh', 'wazuh-wui']:
         if def_user != username:


### PR DESCRIPTION
## Related

- https://github.com/wazuh/wazuh-docker/issues/2404
- https://github.com/wazuh/wazuh-docker/pull/2405

# Description

The aim of this PR is to change the function from the API used to update the users from `wazuh.security` module to `wazuh.rbac.orm` module.

More information about this change in the related PR.