### PR TITLE
Fixed 5.0.0 branch references after bump

### DIFF
--- a/.github/workflows/5_build_and_push_images.yml
+++ b/.github/workflows/5_build_and_push_images.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       image_tag:
         description: 'Docker image tag'
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
         required: true
       docker_reference:
         description: 'wazuh-docker reference'
@@ -14,7 +14,7 @@ on:
       wazuh_automation_reference:
         description: 'Branch or tag of the wazuh-automation repository'
         required: false
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
       products:
         description: 'Comma-separated list of the image names to build and push'
         default: 'wazuh-manager,wazuh-dashboard,wazuh-indexer,wazuh-agent'
@@ -42,7 +42,7 @@ on:
     inputs:
       image_tag:
         description: 'Docker image tag'
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
         required: true
         type: string
       docker_reference:
@@ -52,7 +52,7 @@ on:
       wazuh_automation_reference:
         description: 'Branch or tag of the wazuh-automation repository'
         required: false
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
         type: string
       products:
         description: 'Comma-separated list of the image names to build and push'

--- a/.github/workflows/5_check_integration_tools.yml
+++ b/.github/workflows/5_check_integration_tools.yml
@@ -16,7 +16,7 @@ on:
       automation_reference:
         description: 'Branch of wazuh-automation to use'
         required: false
-        default: 'v5.0.0-beta3'
+        default: '5.0.0'
         type: string
       deployment_type:
         description: 'Deployment type to test'

--- a/.github/workflows/5_pr_check.yml
+++ b/.github/workflows/5_pr_check.yml
@@ -55,7 +55,7 @@ jobs:
     with:
       image_tag: ${{ needs.prepare-variables.outputs.WAZUH_IMAGE_VERSION }}
       docker_reference: ${{ github.head_ref || inputs.docker_reference }}
-      wazuh_automation_reference: 'v5.0.0-beta3'
+      wazuh_automation_reference: '5.0.0'
       commit_list: '["latest", "latest", "latest", "latest"]'
       assistant_revision: 'latest'
       id: ${{ github.run_id }}


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-docker/issues/2475

Fixed 5.0.0 branch references after bump