### PR TITLE
fix: pin compose images to published 5.0.0-beta2 tag (#2391)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2391](https://github.com/wazuh/wazuh-docker/issues/2391) | Pinned the compose deployment images to the published 5.0.0-beta2 tag |
 
 ## Prior versions
 

--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
 services:
   wazuh.master:
-    image: wazuh/wazuh-manager:5.1.0
+    image: wazuh/wazuh-manager:5.0.0-beta2
     hostname: wazuh.master
     container_name: multi-node-wazuh.master
     restart: always
@@ -44,7 +44,7 @@ services:
       - ./config/wazuh_master/certs/wazuh.master-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
 
   wazuh.worker:
-    image: wazuh/wazuh-manager:5.1.0
+    image: wazuh/wazuh-manager:5.0.0-beta2
     hostname: wazuh.worker
     container_name: multi-node-wazuh.worker
     restart: always
@@ -83,7 +83,7 @@ services:
       - ./config/wazuh_worker/certs/wazuh.worker-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
 
   wazuh1.indexer:
-    image: wazuh/wazuh-indexer:5.1.0
+    image: wazuh/wazuh-indexer:5.0.0-beta2
     hostname: wazuh1.indexer
     container_name: multi-node-wazuh1.indexer
     restart: always
@@ -121,7 +121,7 @@ services:
       - ./config/wazuh1_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem
 
   wazuh2.indexer:
-    image: wazuh/wazuh-indexer:5.1.0
+    image: wazuh/wazuh-indexer:5.0.0-beta2
     hostname: wazuh2.indexer
     container_name: multi-node-wazuh2.indexer
     restart: always
@@ -159,7 +159,7 @@ services:
       - ./config/wazuh2_indexer/certs/wazuh2.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem
 
   wazuh3.indexer:
-    image: wazuh/wazuh-indexer:5.1.0
+    image: wazuh/wazuh-indexer:5.0.0-beta2
     hostname: wazuh3.indexer
     container_name: multi-node-wazuh3.indexer
     restart: always
@@ -197,7 +197,7 @@ services:
       - ./config/wazuh3_indexer/certs/wazuh3.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:5.1.0
+    image: wazuh/wazuh-dashboard:5.0.0-beta2
     hostname: wazuh.dashboard
     container_name: multi-node-wazuh.dashboard
     restart: always

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
 services:
   wazuh.manager:
-    image: wazuh/wazuh-manager:5.1.0
+    image: wazuh/wazuh-manager:5.0.0-beta2
     hostname: wazuh.manager
     container_name: single-node-wazuh.manager
     restart: always
@@ -44,7 +44,7 @@ services:
       - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
 
   wazuh.indexer:
-    image: wazuh/wazuh-indexer:5.1.0
+    image: wazuh/wazuh-indexer:5.0.0-beta2
     hostname: wazuh.indexer
     container_name: single-node-wazuh.indexer
     restart: always
@@ -81,7 +81,7 @@ services:
       - ./config/wazuh_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem
 
   wazuh.dashboard:
-    image: wazuh/wazuh-dashboard:5.1.0
+    image: wazuh/wazuh-dashboard:5.0.0-beta2
     hostname: wazuh.dashboard
     container_name: single-node-wazuh.dashboard
     restart: always

--- a/wazuh-agent/docker-compose.yml
+++ b/wazuh-agent/docker-compose.yml
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2017, Wazuh Inc. (License GPLv2)
 services:
   wazuh.agent:
-    image: wazuh/wazuh-agent:5.1.0
+    image: wazuh/wazuh-agent:5.0.0-beta2
     restart: always
     environment:
       - WAZUH_MANAGER_SERVER=<WAZUH_MANAGER_IP>


### PR DESCRIPTION
## Description

`docker compose up` currently fails on `main` because the compose files reference image tags that are **not published on Docker Hub**:

```
$ docker compose up -d
Error response from daemon: manifest for wazuh/wazuh-manager:5.0.1 not found: manifest unknown
```

The `single-node`, `multi-node`, and `wazuh-agent` compose files all point at `wazuh/wazuh-*:5.0.1`. No `5.0.1` image exists for `wazuh-manager`, `wazuh-indexer`, `wazuh-dashboard`, or `wazuh-agent` — the only published v5 images are `5.0.0-beta1-latest` and `5.0.0-beta2`.

## Root cause

`5.0.x` is still pre-release. The branch was bumped to `5.0.1` (VERSION.json `stage: alpha0`) before any `5.0.1` artifacts were published, so every image reference resolves to a non-existent manifest.

Downgrading to the `4.14.x` stable line is **not** a valid fix here: the config files on this branch use the 5.0 layout (e.g. `/var/wazuh-manager/...` paths, the 5.x dashboard cert layout), which is incompatible with 4.x images. The latest published image that is compatible with these configs is `5.0.0-beta2`.

## Change

Pin all image references to `5.0.0-beta2` across the three compose files (10 references total).

## Validation

```
# Old tag — reproduces the reported error
$ docker manifest inspect wazuh/wazuh-manager:5.0.1
manifest unknown

# New tag — resolves for all four components
$ docker manifest inspect wazuh/wazuh-manager:5.0.0-beta2    # OK
$ docker manifest inspect wazuh/wazuh-indexer:5.0.0-beta2    # OK
$ docker manifest inspect wazuh/wazuh-dashboard:5.0.0-beta2  # OK
$ docker manifest inspect wazuh/wazuh-agent:5.0.0-beta2      # OK
```

`docker compose config` parses cleanly for `single-node`, `multi-node`, and `wazuh-agent`, rendering the new tags.

Fixes #2391