### PR TITLE
Fixed login in Docker Hub before triggering the QEMU action

### DIFF
--- a/.github/workflows/Procedure_push_docker_images.yml
+++ b/.github/workflows/Procedure_push_docker_images.yml
@@ -155,6 +155,12 @@ jobs:
       with:
         ref: ${{ inputs.docker_reference }}
 
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v4
 
@@ -171,12 +177,6 @@ jobs:
     - name: Log in to Amazon ECR
       if: ${{ inputs.dev == true }}
       uses: aws-actions/amazon-ecr-login@v2
-
-    - name: Log in to Docker Hub
-      uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Build Wazuh images
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed login in Docker Hub before triggering the QEMU action ([#2494](https://github.com/wazuh/wazuh-docker/pull/2494))
 - Changed update_user function from wazuh.security to wazuh.rbac.orm module ([#2406](https://github.com/wazuh/wazuh-docker/pull/2406))
 - GH issue notification fix ([#2312](https://github.com/wazuh/wazuh-docker/pull/2312))
 


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-docker/issues/2492

# Description

The `setup-qemu-action` pulls an image from Docker. We were reaching the limit of downloads without having logged in.
We have changed the steps order so we log in Docker Hub before triggering that action.

## Tests

Test: https://github.com/wazuh/wazuh-docker/actions/runs/28231670268