### PR TITLE
Add SELinux relabel labels for rootless Podman support (#1824)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#1824](https://github.com/wazuh/wazuh-docker/issues/1824) | Added SELinux relabel options to the compose bind mounts and a rootless Podman deployment guide |
 
 ### Changed
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Deployment](ref/getting-started/deployment/deployment.md)
     - [Single Node Wazuh Stack](ref/getting-started/deployment/single-node.md)
     - [Multi Node Wazuh Stack](ref/getting-started/deployment/multi-node.md)
+    - [Rootless Podman with SELinux](ref/getting-started/deployment/rootless-podman.md)
     - [Wazuh Agent](ref/getting-started/deployment/wazuh-agent.md)
 - [Configuration](ref/configuration/configuration.md)
   - [Environment Variabless](ref/configuration/environment-variables.md)

--- a/docs/ref/getting-started/deployment/deployment.md
+++ b/docs/ref/getting-started/deployment/deployment.md
@@ -18,6 +18,13 @@ Wazuh-Docker offers flexibility in how you can deploy the Wazuh stack. The prima
     * **Pros**: Improved fault tolerance (for clustered components like the Indexer), better performance distribution.
     * **Cons**: More complex to set up and manage than a single-node deployment.
 
+### Alternative container engine
+
+-   **[Rootless Podman with SELinux](rootless-podman.md)**: Both the single-node and
+    multi-node compose files also run under rootless Podman on SELinux-enforcing
+    hosts. This guide covers the additional host preparation required. The standard
+    `docker compose` workflow remains the officially supported method.
+
 ## Before You Begin Deployment
 
 Ensure you have:

--- a/docs/ref/getting-started/deployment/rootless-podman.md
+++ b/docs/ref/getting-started/deployment/rootless-podman.md
@@ -1,0 +1,156 @@
+# Wazuh Docker Deployment
+
+## Deploying Wazuh on Rootless Podman with SELinux
+
+The `single-node/docker-compose.yml` and `multi-node/docker-compose.yml` files are
+compatible with [Podman](https://podman.io/) in **rootless** mode on hosts with
+SELinux in **enforcing** mode. The bind-mounted certificate and configuration files
+carry the `:z` SELinux relabel option, so Podman relabels them with a container
+context automatically. On Docker hosts (or hosts without SELinux) the `:z` option is
+ignored, so the same files work unchanged in both engines.
+
+This guide covers the host preparation needed for a rootless deployment and the
+differences from the standard Docker workflow. It has been validated with
+`podman` 5.x and `podman-compose` 1.3.x on Rocky Linux 9.
+
+> **Note:** Rootless Podman support is community-contributed. The official, fully
+> supported deployment method remains `docker compose`.
+
+### 1. Host preparation (run as root)
+
+1.  Increase `vm.max_map_count`, required by the Wazuh indexer:
+
+    ```bash
+    echo "vm.max_map_count=262144" >> /etc/sysctl.conf
+    sysctl -p
+    ```
+
+2.  Install Podman and the Netavark network stack:
+
+    ```bash
+    dnf install -y podman netavark aardvark-dns python3-pip
+    ```
+
+    Make sure `network_backend = "netavark"` is set in
+    `/usr/share/containers/containers.conf`.
+
+3.  Keep the user's systemd instance alive after logout, so the containers keep
+    running when the user is not logged in. Replace `<user>` with the unprivileged
+    account that will own the deployment:
+
+    ```bash
+    loginctl enable-linger <user>
+    ```
+
+4.  Raise the `memlock` and `nofile` limits the indexer and manager require. Add to
+    `/etc/security/limits.conf` and re-login for the change to take effect:
+
+    ```
+    <user>  hard  memlock   -1
+    <user>  hard  nofile    655360
+    ```
+
+5.  If `firewalld` is running (the default on RHEL-family hosts), open the ports the
+    stack publishes so agents and users can reach it from other hosts:
+
+    ```bash
+    firewall-cmd --permanent --add-port=443/tcp   # Wazuh dashboard
+    firewall-cmd --permanent --add-port=1514/tcp  # Agent connection
+    firewall-cmd --permanent --add-port=1515/tcp  # Agent enrollment
+    firewall-cmd --permanent --add-port=514/udp   # Syslog collector
+    firewall-cmd --permanent --add-port=55000/tcp # Wazuh manager API
+    firewall-cmd --reload
+    ```
+
+    Add `9200/tcp` as well if the indexer REST API must be reachable from outside
+    the host.
+
+### 2. Binding to privileged ports (optional)
+
+The dashboard publishes on host port `443` and the manager on `514/udp`. Rootless
+containers cannot bind to ports below `1024` by default. Either publish the services
+on high ports (for example, map `443:5601` to `8443:5601` in the compose file), or
+lower the unprivileged-port threshold on the host (run as root):
+
+```bash
+# Permanent
+echo "net.ipv4.ip_unprivileged_port_start=443" >> /etc/sysctl.conf
+sysctl -p
+```
+
+### 3. Generate the certificates
+
+Run the certificate steps as the unprivileged user from inside the deployment
+directory (`single-node` or `multi-node`), exactly as in the Docker workflow:
+
+```bash
+curl -o wazuh-certs-tool.sh https://packages.wazuh.com/5.0/wazuh-certs-tool-5.1.0-1.sh
+curl -o config.yml https://packages.wazuh.com/5.0/config-5.1.0-1.yml
+# Edit config.yml with your node names, then:
+bash ../tools/utils/deployment/certificates-conf.sh --cert --copy
+```
+
+> **Rootless certificate ownership:** The `--priv` flag of `certificates-conf.sh`
+> runs `chown 101:101` and `chmod 400` on the certificate files. Under rootless
+> Podman the container's UID `101` is mapped to a high subordinate UID on the host,
+> not host UID `101`, so an ownership set by `--priv` will not match the in-container
+> user and the files become unreadable inside the container.
+>
+> For rootless deployments, **omit `--priv`** (the relabel granted by `:z` plus the
+> default read permissions are sufficient), or set ownership through the user
+> namespace instead:
+>
+> ```bash
+> podman unshare chown -R 101:101 config/*/certs
+> ```
+
+### 4. Start the stack
+
+From the `single-node` or `multi-node` directory:
+
+```bash
+podman-compose --in-pod=true up -d
+```
+
+To manage the deployment with systemd, a simple user service that wraps
+`podman-compose` keeps the standard compose files as the single source of truth:
+
+```ini
+# ~/.config/systemd/user/wazuh.service
+[Unit]
+Description=Wazuh (podman-compose)
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+WorkingDirectory=%h/wazuh-docker/single-node
+ExecStart=%h/.local/bin/podman-compose --in-pod=true up -d
+ExecStop=%h/.local/bin/podman-compose down
+
+[Install]
+WantedBy=default.target
+```
+
+Enable it with `systemctl --user enable --now wazuh.service`.
+
+### Troubleshooting
+
+-   **`Permission denied` writing to `/certificates` or reading certs:** Confirm the
+    bind mounts in your compose file end with `:z`. If SELinux is enforcing, check
+    for denials with `ausearch -m avc -ts recent`.
+-   **AVC denials persist even with `:z` mounts:** The host files may carry stale or
+    wrong SELinux labels (common after copying the repository from another location
+    or unpacking it from an archive). Reset them to the system defaults and retry:
+
+    ```bash
+    restorecon -Rv ~/wazuh-docker
+    ```
+
+    On a freshly provisioned host with widespread mislabeling, a full-system relabel
+    may be required instead: `touch /.autorelabel && reboot` (or `restorecon -r /`).
+-   **`bootstrap check failure ... max virtual memory areas`:** `vm.max_map_count`
+    was not applied; re-run step 1.
+-   **Containers cannot bind port 443/514:** Apply the unprivileged-port change in
+    step 2 or remap to high ports.

--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -39,9 +39,9 @@ services:
       - master-wazuh-logs:/var/wazuh-manager/logs
       - master-wazuh-queue:/var/wazuh-manager/queue
       - master-wazuh-var-multigroups:/var/wazuh-manager/var/multigroups
-      - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem
-      - ./config/wazuh_master/certs/wazuh.master.pem:/var/wazuh-manager/etc/certs/manager.pem
-      - ./config/wazuh_master/certs/wazuh.master-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
+      - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem:z
+      - ./config/wazuh_master/certs/wazuh.master.pem:/var/wazuh-manager/etc/certs/manager.pem:z
+      - ./config/wazuh_master/certs/wazuh.master-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem:z
 
   wazuh.worker:
     image: wazuh/wazuh-manager:5.1.0
@@ -78,9 +78,9 @@ services:
       - worker-wazuh-logs:/var/wazuh-manager/logs
       - worker-wazuh-queue:/var/wazuh-manager/queue
       - worker-wazuh-var-multigroups:/var/wazuh-manager/var/multigroups
-      - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem
-      - ./config/wazuh_worker/certs/wazuh.worker.pem:/var/wazuh-manager/etc/certs/manager.pem
-      - ./config/wazuh_worker/certs/wazuh.worker-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
+      - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem:z
+      - ./config/wazuh_worker/certs/wazuh.worker.pem:/var/wazuh-manager/etc/certs/manager.pem:z
+      - ./config/wazuh_worker/certs/wazuh.worker-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem:z
 
   wazuh1.indexer:
     image: wazuh/wazuh-indexer:5.1.0
@@ -114,11 +114,11 @@ services:
       start_period: 60s
     volumes:
       - wazuh-indexer-data-1:/var/lib/wazuh-indexer
-      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem
-      - ./config/wazuh1_indexer/certs/wazuh1.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem
-      - ./config/wazuh1_indexer/certs/wazuh1.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem
-      - ./config/wazuh1_indexer/certs/admin.pem:/usr/share/wazuh-indexer/config/certs/admin.pem
-      - ./config/wazuh1_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem
+      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem:z
+      - ./config/wazuh1_indexer/certs/wazuh1.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem:z
+      - ./config/wazuh1_indexer/certs/wazuh1.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem:z
+      - ./config/wazuh1_indexer/certs/admin.pem:/usr/share/wazuh-indexer/config/certs/admin.pem:z
+      - ./config/wazuh1_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem:z
 
   wazuh2.indexer:
     image: wazuh/wazuh-indexer:5.1.0
@@ -154,9 +154,9 @@ services:
       start_period: 60s
     volumes:
       - wazuh-indexer-data-2:/var/lib/wazuh-indexer
-      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem
-      - ./config/wazuh2_indexer/certs/wazuh2.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem
-      - ./config/wazuh2_indexer/certs/wazuh2.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem
+      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem:z
+      - ./config/wazuh2_indexer/certs/wazuh2.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem:z
+      - ./config/wazuh2_indexer/certs/wazuh2.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem:z
 
   wazuh3.indexer:
     image: wazuh/wazuh-indexer:5.1.0
@@ -192,9 +192,9 @@ services:
       start_period: 60s
     volumes:
       - wazuh-indexer-data-3:/var/lib/wazuh-indexer
-      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem
-      - ./config/wazuh3_indexer/certs/wazuh3.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem
-      - ./config/wazuh3_indexer/certs/wazuh3.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem
+      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem:z
+      - ./config/wazuh3_indexer/certs/wazuh3.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem:z
+      - ./config/wazuh3_indexer/certs/wazuh3.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem:z
 
   wazuh.dashboard:
     image: wazuh/wazuh-dashboard:5.1.0
@@ -220,9 +220,9 @@ services:
       - SERVER_SSL_KEY=/usr/share/wazuh-dashboard/config/certs/wazuh-dashboard-key.pem
       - OPENSEARCH_SSL_CERTIFICATE_AUTHORITIES=/usr/share/wazuh-dashboard/config/certs/root-ca.pem
     volumes:
-      - ./config/wazuh_dashboard/certs/wazuh.dashboard.pem:/usr/share/wazuh-dashboard/config/certs/wazuh-dashboard.pem
-      - ./config/wazuh_dashboard/certs/wazuh.dashboard-key.pem:/usr/share/wazuh-dashboard/config/certs/wazuh-dashboard-key.pem
-      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-dashboard/config/certs/root-ca.pem
+      - ./config/wazuh_dashboard/certs/wazuh.dashboard.pem:/usr/share/wazuh-dashboard/config/certs/wazuh-dashboard.pem:z
+      - ./config/wazuh_dashboard/certs/wazuh.dashboard-key.pem:/usr/share/wazuh-dashboard/config/certs/wazuh-dashboard-key.pem:z
+      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-dashboard/config/certs/root-ca.pem:z
       - wazuh-dashboard-config:/usr/share/wazuh-dashboard/config
       - wazuh-dashboard-custom:/usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom
     depends_on:
@@ -243,7 +243,7 @@ services:
       - wazuh.worker
       - wazuh.dashboard
     volumes:
-      - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro,z
 
 volumes:
   master-wazuh-api-configuration:

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -39,9 +39,9 @@ services:
       - wazuh_logs:/var/wazuh-manager/logs
       - wazuh_queue:/var/wazuh-manager/queue
       - wazuh_var_multigroups:/var/wazuh-manager/var/multigroups
-      - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem
-      - ./config/wazuh_manager/certs/wazuh.manager.pem:/var/wazuh-manager/etc/certs/manager.pem
-      - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
+      - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem:z
+      - ./config/wazuh_manager/certs/wazuh.manager.pem:/var/wazuh-manager/etc/certs/manager.pem:z
+      - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem:z
 
   wazuh.indexer:
     image: wazuh/wazuh-indexer:5.1.0
@@ -74,11 +74,11 @@ services:
       start_period: 60s
     volumes:
       - wazuh-indexer-data:/var/lib/wazuh-indexer
-      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem
-      - ./config/wazuh_indexer/certs/wazuh.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem
-      - ./config/wazuh_indexer/certs/wazuh.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem
-      - ./config/wazuh_indexer/certs/admin.pem:/usr/share/wazuh-indexer/config/certs/admin.pem
-      - ./config/wazuh_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem
+      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-indexer/config/certs/root-ca.pem:z
+      - ./config/wazuh_indexer/certs/wazuh.indexer-key.pem:/usr/share/wazuh-indexer/config/certs/indexer-key.pem:z
+      - ./config/wazuh_indexer/certs/wazuh.indexer.pem:/usr/share/wazuh-indexer/config/certs/indexer.pem:z
+      - ./config/wazuh_indexer/certs/admin.pem:/usr/share/wazuh-indexer/config/certs/admin.pem:z
+      - ./config/wazuh_indexer/certs/admin-key.pem:/usr/share/wazuh-indexer/config/certs/admin-key.pem:z
 
   wazuh.dashboard:
     image: wazuh/wazuh-dashboard:5.1.0
@@ -104,9 +104,9 @@ services:
       - SERVER_SSL_KEY=/usr/share/wazuh-dashboard/config/certs/dashboard-key.pem
       - OPENSEARCH_SSL_CERTIFICATE_AUTHORITIES=/usr/share/wazuh-dashboard/config/certs/root-ca.pem
     volumes:
-      - ./config/wazuh_dashboard/certs/wazuh.dashboard.pem:/usr/share/wazuh-dashboard/config/certs/dashboard.pem
-      - ./config/wazuh_dashboard/certs/wazuh.dashboard-key.pem:/usr/share/wazuh-dashboard/config/certs/dashboard-key.pem
-      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-dashboard/config/certs/root-ca.pem
+      - ./config/wazuh_dashboard/certs/wazuh.dashboard.pem:/usr/share/wazuh-dashboard/config/certs/dashboard.pem:z
+      - ./config/wazuh_dashboard/certs/wazuh.dashboard-key.pem:/usr/share/wazuh-dashboard/config/certs/dashboard-key.pem:z
+      - ./config/root-ca/certs/root-ca.pem:/usr/share/wazuh-dashboard/config/certs/root-ca.pem:z
       - wazuh-dashboard-config:/usr/share/wazuh-dashboard/config
       - wazuh-dashboard-custom:/usr/share/wazuh-dashboard/plugins/wazuh/public/assets/custom
     depends_on:


### PR DESCRIPTION
## Description

Adds support for deploying the Wazuh stack under **rootless Podman on SELinux-enforcing hosts**, as requested in #1824, without affecting the default `docker compose` workflow.

### Changes

- Append the `:z` SELinux relabel option to every certificate/config bind mount in `single-node/docker-compose.yml` and `multi-node/docker-compose.yml`, and `:ro,z` to the nginx config mount. This resolves the `Permission denied` errors on mounted certificates under rootless Podman + SELinux.
- Add a deployment guide: `docs/ref/getting-started/deployment/rootless-podman.md` (host prep, privileged ports, the rootless certificate-ownership caveat, and a systemd user unit wrapping `podman-compose`). Wired into `SUMMARY.md` and the deployment overview.

### Why this is safe for Docker

`:z` is an SELinux relabel request. On Docker hosts and hosts without SELinux it is **ignored** (a no-op), so the default deployment is unchanged. `:z` (shared) rather than `:Z` (private) is used because `root-ca.pem` is mounted into multiple containers.

### Scope

This PR is intentionally limited to the SELinux relabel fix (the permission problem in the issue title) plus documentation. The pod-networking / UID-mapping concerns raised later in the thread are a separate topic and are not addressed here.

### Testing

- `docker compose config -q` passes on both compose files.
- Diff is suffix-only; no structural changes.
- Named volumes are left unlabeled (Podman relabels those automatically).

Closes #1824