### PR TITLE
Fix changelog check to accept Prior versions entries

### DIFF
--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -37,8 +37,12 @@ jobs:
             INVALID=$(echo "$ADDED" | grep -E '^(\||-)' | grep -vx -- '- None' | grep -vE "$TABLE_HEADER_REGEX" | grep -vE "$TABLE_ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
-              echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))' or, for the Prior versions section, '- [vX.X.X](https://github.com/<org>/<repo>/blob/vX.X.X/CHANGELOG.md)'. Offending lines:"
+              echo "::error::Invalid CHANGELOG.md entries. Offending lines:"
               echo "$INVALID"
+              echo "::error::Expected formats:"
+              echo "::error::  - Table entry: '| [#123](https://github.com/<org>/<repo>/issues/123) | Description |'"
+              echo "::error::  - Prior versions entry: '- [vX.Y.Z](https://github.com/<org>/<repo>/blob/vX.Y.Z/CHANGELOG.md)'"
+              echo "::error::  - Prior versions placeholder (no prior version): '- []()'"
             fi
           fi
 

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -31,9 +31,10 @@ jobs:
           else
             FORMAT="✅"
 
-            ENTRY_REGEX='^- .+ \(\[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\)\)$'
-            PRIOR_VERSION_REGEX='^- \[v[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/v[0-9]+\.[0-9]+\.[0-9]+/CHANGELOG\.md\)$'
-            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
+            TABLE_ENTRY_REGEX='^\| \[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\) \| .+ \|$'
+            TABLE_HEADER_REGEX='^\| Issue \| Comment \|$|^\| - \| - \|$'
+            PRIOR_VERSION_REGEX='^- \[v?[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/[^)]+/CHANGELOG\.md\)$|^- \[\]\(\)$'
+            INVALID=$(echo "$ADDED" | grep -E '^(\||-)' | grep -vx -- '- None' | grep -vE "$TABLE_HEADER_REGEX" | grep -vE "$TABLE_ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
               echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))' or, for the Prior versions section, '- [vX.X.X](https://github.com/<org>/<repo>/blob/vX.X.X/CHANGELOG.md)'. Offending lines:"

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -32,10 +32,11 @@ jobs:
             FORMAT="✅"
 
             ENTRY_REGEX='^- .+ \(\[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\)\)$'
-            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" || true)
+            PRIOR_VERSION_REGEX='^- \[v[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/v[0-9]+\.[0-9]+\.[0-9]+/CHANGELOG\.md\)$'
+            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
-              echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'. Offending lines:"
+              echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))' or, for the Prior versions section, '- [vX.X.X](https://github.com/<org>/<repo>/blob/vX.X.X/CHANGELOG.md)'. Offending lines:"
               echo "$INVALID"
             fi
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2563](https://github.com/wazuh/wazuh-docker/issues/2563) | Fixed changelog check workflow to accept Prior versions entries |
 | [#2533](https://github.com/wazuh/wazuh-docker/pull/2533) | Fix bumper workflow failure when bump produces no changes |
 | [#2477](https://github.com/wazuh/wazuh-docker/issues/2477) | Bumper script issue when the tag is set to false |
 | [#2443](https://github.com/wazuh/wazuh-docker/issues/2443) | Fix reported WF vulnerabilities |


### PR DESCRIPTION
## Description

The `5.x Changelog check` workflow only validated entries matching the PR/Issue link format (`- Description ([#123](.../issues/123))`), causing it to fail on legitimate `## Prior versions` entries (`- [vX.X.X](.../blob/vX.X.X/CHANGELOG.md)`), as described in #3657.

This PR adds a second accepted pattern (`PRIOR_VERSION_REGEX`) so Prior versions entries validate correctly, without changing how standard PR/Issue entries are validated.

## Tests

Verified with test PRs (not to be merged):
- Standard entry (valid): #2566  →  passed
- Prior versions entry (valid): #2565  →  passed
- Both sections combined (valid): #2567  → passed
- Invalid format entry: #2568  →  failed 

## Related issue

https://github.com/wazuh/wazuh-automation/issues/3657