### PR TITLE
Add explicit permissions on workflows

### DIFF
--- a/.github/workflows/4_build_and_push_images.yml
+++ b/.github/workflows/4_build_and_push_images.yml
@@ -213,6 +213,10 @@ jobs:
 
   notify:
     runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    
+    permissions:
+      contents: read
+      
     needs: [setup, build-and-push]
     # Only run if NOT dev AND all products were selected
     if: ${{ inputs.dev == false && needs.setup.outputs.ALL_PRODUCTS_SELECTED == 'true' }}

--- a/.github/workflows/4_build_and_push_images.yml
+++ b/.github/workflows/4_build_and_push_images.yml
@@ -213,10 +213,10 @@ jobs:
 
   notify:
     runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
-    
+
     permissions:
       contents: read
-      
+
     needs: [setup, build-and-push]
     # Only run if NOT dev AND all products were selected
     if: ${{ inputs.dev == false && needs.setup.outputs.ALL_PRODUCTS_SELECTED == 'true' }}

--- a/.github/workflows/4_pr_check.yml
+++ b/.github/workflows/4_pr_check.yml
@@ -14,7 +14,7 @@ on:
 
 permissions:
   contents: read
-  
+
 env:
   ARTIFACTS_LOCAL_DIR: /home/runner/work/wazuh-docker/wazuh-docker/docker-images
   ARTIFACT_NAMES: |

--- a/.github/workflows/4_pr_check.yml
+++ b/.github/workflows/4_pr_check.yml
@@ -12,6 +12,9 @@ on:
       - 'wazuh-agent/**'
       - '.github/**'
 
+permissions:
+  contents: read
+  
 env:
   ARTIFACTS_LOCAL_DIR: /home/runner/work/wazuh-docker/wazuh-docker/docker-images
   ARTIFACT_NAMES: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 | Issue | Comment |
 | - | - |
-
+- Added explicit `permissions` blocks to the 4.x workflows to restrict the `GITHUB_TOKEN` scope ([#2461](https://github.com/wazuh/wazuh-docker/issues/2461))
 ### Removed
 
 | Issue | Comment |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 
 | Issue | Comment |
 | - | - |
-- Added explicit `permissions` blocks to the 4.x workflows to restrict the `GITHUB_TOKEN` scope ([#2461](https://github.com/wazuh/wazuh-docker/issues/2461))
+| [#2461](https://github.com/wazuh/wazuh-docker/issues/2461) | Added explicit `permissions` blocks to the 4.x workflows to restrict the `GITHUB_TOKEN` scope |
+
 ### Removed
 
 | Issue | Comment |


### PR DESCRIPTION
## Related issue

Closes #2461

## Description

Adds explicit `permissions` blocks to the 4.x workflows to restrict the scope of the `GITHUB_TOKEN`, resolving the CodeQL alert *"Workflow does not contain permissions"* raised during the review of #2446.

When a workflow or job does not declare `permissions`, the `GITHUB_TOKEN` falls back to the repository/organization default, which is usually far broader than what the job actually needs. If any step were compromised — including a third-party action — that token could be used to write to the repository. Declaring the minimum required scope
limits the blast radius.

Two gaps were found; the remaining workflows already declare `permissions` explicitly.

| File | Scope | Value applied |
|---|---|---|
| `.github/workflows/4_pr_check.yml` | workflow level | `contents: read` |
| `.github/workflows/4_build_and_push_images.yml` | job `notify` | `contents: read` |

## Review of the Copilot suggestions

Not every suggestion was applied verbatim. Full reasoning is in the comment on #2461;
summary:

- **`4_pr_check.yml`** — the suggestion adding `actions: read`, `packages: read` and  `pull-requests: read` was rejected as over-provisioned. The three jobs only run `actions/checkout`, `docker/login-action` (Docker Hub credentials from secrets) and `aws s3` calls; nothing touches the GitHub API. `contents: read` is sufficient.
- **`4_build_and_push_images.yml`, job `notify`** — the suggestion adding `issues: write` and `projects: write` was rejected. `projects` is not a valid permission scope and the workflow would fail to parse (`actionlint`: `unknown permission scope "projects"`). Beyond that, the job does not use `GITHUB_TOKEN` at all: `gh` is authenticated with `secrets.NOTIFICATION_GH_ARTIFACT_TOKEN`, and it targets a different repository plus an organization-level Projects v2 board, neither of which `GITHUB_TOKEN` can reach under any permission combination. The CodeQL alert itself suggests `{}` for this job.

## Testing performed

- `actionlint` on both modified workflows: **no new findings** versus `main` (the 3 pre-existing `workflow_call` input warnings are unchanged).
- `4_build_and_push_images.yml` was **not** executed: its `notify` job only runs on the production path (`dev == false`), which pushes images to Docker Hub. Happy to run it if the team confirms it is safe.

## Notes for the reviewer

- `4_pr_check.yml` filters on `branches: 4.*`, so it is **not** triggered by a PR targeting `main` and is not exercised here. Let me know if the change should also be backported to the active 4.x branches.
- `contents: read` was used for the `notify` job rather than `{}`, for consistency with the other jobs in the repository. Happy to switch it to `{}` if we prefer the strictest value, since that job does not even run `actions/checkout`.