### PR TITLE
Add security parameters on workflows (5.0.0 backport)

### DIFF
--- a/.github/workflows/4_build_and_push_images.yml
+++ b/.github/workflows/4_build_and_push_images.yml
@@ -213,6 +213,10 @@ jobs:
 
   notify:
     runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+
+    permissions:
+      contents: read
+
     needs: [setup, build-and-push]
     # Only run if NOT dev AND all products were selected
     if: ${{ inputs.dev == false && needs.setup.outputs.ALL_PRODUCTS_SELECTED == 'true' }}

--- a/.github/workflows/4_pr_check.yml
+++ b/.github/workflows/4_pr_check.yml
@@ -12,6 +12,9 @@ on:
       - 'wazuh-agent/**'
       - '.github/**'
 
+permissions:
+  contents: read
+
 env:
   ARTIFACTS_LOCAL_DIR: /home/runner/work/wazuh-docker/wazuh-docker/docker-images
   ARTIFACT_NAMES: |


### PR DESCRIPTION
## Related issue

Related to #2461

## Description

Backport of the `permissions` hardening to the `5.0.0` branch, as requested in review.

Workflows live per branch, and for `pull_request` events GitHub runs the workflow file from the base branch — so fixing `main` alone leaves `5.0.0` unprotected and keeps the CodeQL alert open there.

| File | Scope | Value applied |
|---|---|---|
| `.github/workflows/4_pr_check.yml` | workflow level | `contents: read` |
| `.github/workflows/4_build_and_push_images.yml` | job `notify` | `contents: read` |

Both files are byte-identical to their counterparts in `main`, so the change ports without adaptation. The reasoning for rejecting parts of the original Copilot suggestions is in the comment on #2461.

## CHANGELOG

Intentionally not updated on this release branch, as agreed in review. The `no-changelog` label is applied so `5_changelog_check.yml` is skipped.

## Testing performed

- `actionlint` on both modified workflows: no new findings versus `5.0.0` (the 3 pre-existing `workflow_call` input warnings are unchanged).

- `4_pr_check.yml` filters on `branches: 4.*`, so it is not triggered by a PR targeting  `5.0.0` and is not exercised here.
- `4_build_and_push_images.yml` was not executed: its `notify` job only runs on the production path (`dev == false`), which pushes images to Docker Hub.