### PR TITLE
Adapt Allocator install and invocation to new Python package

### DIFF
--- a/.github/workflows/5_check_integration_tools.yml
+++ b/.github/workflows/5_check_integration_tools.yml
@@ -407,7 +407,7 @@ jobs:
 
       - name: Install requirements
         run: |
-          pip install -r wazuh-automation/deployability/deps/requirements.txt
+          pip install ./wazuh-automation/deployability/modules/allocation
           pip install -r wazuh-automation/integration-test-module/requirements.txt
           pip install -e wazuh-automation/integration-test-module/
           pip install pyyaml
@@ -439,7 +439,7 @@ jobs:
         id: allocate
         run: |
           mkdir -p ${{ env.ALLOCATOR_PATH }}
-          python3 wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action create \
             --provider aws \
             --size large \
@@ -847,7 +847,7 @@ jobs:
       - name: Deallocate instance
         if: always()
         run: |
-          python3 wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action delete \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 | Issue | Comment |
 | - | - |
 | [#2585](https://github.com/wazuh/wazuh-docker/pull/2585) | Adapt Allocator invocation to the new installable Python package |
+| [#2564](https://github.com/wazuh/wazuh-docker/issues/2564) | Add default AI assistant encryption key in the post installation script |
 | [#2581](https://github.com/wazuh/wazuh-docker/issues/2581) | Change Codebuild runners to Github runners |
 | [#2537](https://github.com/wazuh/wazuh-docker/issues/2537) | Update deployment for Wazuh Indexer 5.0.0 RBAC |
 | [#2539](https://github.com/wazuh/wazuh-docker/pull/2539) | Add new WF for changelog check |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2585](https://github.com/wazuh/wazuh-docker/pull/2585) | Adapt Allocator invocation to the new installable Python package |
 | [#2581](https://github.com/wazuh/wazuh-docker/issues/2581) | Change Codebuild runners to Github runners |
 | [#2537](https://github.com/wazuh/wazuh-docker/issues/2537) | Update deployment for Wazuh Indexer 5.0.0 RBAC |
 | [#2539](https://github.com/wazuh/wazuh-docker/pull/2539) | Add new WF for changelog check |

--- a/docs/ref/integration_test/docker_integration_tests.md
+++ b/docs/ref/integration_test/docker_integration_tests.md
@@ -162,7 +162,7 @@ Runs once per entry in `deployment_matrix`. Each instance provisions its own VM.
 Provisions a dedicated AWS VM using the `deployability` allocator module:
 
 ```bash
-python3 wazuh-automation/deployability/modules/allocation/main.py \
+wazuh-allocator \
   --action create \
   --provider aws \
   --size large \
@@ -271,7 +271,7 @@ For details on what `docker-single-node` and `docker-multi-node` test types vali
 1. `docker compose down -v` on the VM (stops containers and removes volumes)
 2. Deallocate the VM:
    ```bash
-   python3 wazuh-automation/deployability/modules/allocation/main.py \
+   wazuh-allocator \
      --action delete \
      --track-output {ALLOCATOR_PATH}/track.yml
    ```


### PR DESCRIPTION
Updates this workflow to use the Allocator's new package interface: installs it via `pip install ./wazuh-automation/deployability/modules/allocation` instead of the removed `requirements.txt`, and switches both invocations (allocate/deallocate) from direct `main.py` execution to the `wazuh-allocator` console entry point. 

## Related to
https://github.com/wazuh/internal-devel-requests/issues/5888