### PR TITLE
Adapt manager certificate deployment to unified layout

### DIFF
--- a/.github/workflows/5_check_integration_tools.yml
+++ b/.github/workflows/5_check_integration_tools.yml
@@ -691,6 +691,14 @@ jobs:
             sudo docker compose ps
           "
 
+      - name: Apply certificate ownership/permissions (--priv) for #2584 evidence
+        run: |
+          DEPLOYMENT="${{ matrix.deployment_type }}"
+          ssh ${{ env.SSH_OPTS }} "${{ env.REMOTE }}" "
+            cd /tmp/wazuh-docker/${DEPLOYMENT}
+            sudo bash /tmp/wazuh-docker/tools/utils/deployment/certificates-conf.sh --priv
+          "
+
       - name: Verify certificate ownership and modes (evidence for #2584)
         run: |
           DEPLOYMENT="${{ matrix.deployment_type }}"

--- a/.github/workflows/5_check_integration_tools.yml
+++ b/.github/workflows/5_check_integration_tools.yml
@@ -691,6 +691,23 @@ jobs:
             sudo docker compose ps
           "
 
+      - name: Verify certificate ownership and modes (evidence for #2584)
+        run: |
+          DEPLOYMENT="${{ matrix.deployment_type }}"
+          ssh ${{ env.SSH_OPTS }} "${{ env.REMOTE }}" "
+            cd /tmp/wazuh-docker/${DEPLOYMENT}
+            echo '=== Manager certificate ownership and modes (issue #2584 evidence) ==='
+            for SERVICE in wazuh.manager wazuh.master wazuh.worker; do
+              if sudo docker compose ps --services 2>/dev/null | grep -qx \"\$SERVICE\"; then
+                echo \"--- Service: \$SERVICE ---\"
+                echo '[Directory etc/certs]'
+                sudo docker compose exec -T \"\$SERVICE\" ls -ld /var/wazuh-manager/etc/certs
+                echo '[Certificate files]'
+                sudo docker compose exec -T \"\$SERVICE\" ls -la /var/wazuh-manager/etc/certs
+              fi
+            done
+          "
+
       # -----------------------------------------------------------------------
       # Run integration tests
       # -----------------------------------------------------------------------

--- a/.github/workflows/5_check_integration_tools.yml
+++ b/.github/workflows/5_check_integration_tools.yml
@@ -691,31 +691,6 @@ jobs:
             sudo docker compose ps
           "
 
-      - name: Apply certificate ownership/permissions (--priv) for #2584 evidence
-        run: |
-          DEPLOYMENT="${{ matrix.deployment_type }}"
-          ssh ${{ env.SSH_OPTS }} "${{ env.REMOTE }}" "
-            cd /tmp/wazuh-docker/${DEPLOYMENT}
-            sudo bash /tmp/wazuh-docker/tools/utils/deployment/certificates-conf.sh --priv
-          "
-
-      - name: Verify certificate ownership and modes (evidence for #2584)
-        run: |
-          DEPLOYMENT="${{ matrix.deployment_type }}"
-          ssh ${{ env.SSH_OPTS }} "${{ env.REMOTE }}" "
-            cd /tmp/wazuh-docker/${DEPLOYMENT}
-            echo '=== Manager certificate ownership and modes (issue #2584 evidence) ==='
-            for SERVICE in wazuh.manager wazuh.master wazuh.worker; do
-              if sudo docker compose ps --services 2>/dev/null | grep -qx \"\$SERVICE\"; then
-                echo \"--- Service: \$SERVICE ---\"
-                echo '[Directory etc/certs]'
-                sudo docker compose exec -T \"\$SERVICE\" ls -ld /var/wazuh-manager/etc/certs
-                echo '[Certificate files]'
-                sudo docker compose exec -T \"\$SERVICE\" ls -la /var/wazuh-manager/etc/certs
-              fi
-            done
-          "
-
       # -----------------------------------------------------------------------
       # Run integration tests
       # -----------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2584](https://github.com/wazuh/wazuh-docker/issues/2584) | Adapt certificate deployment to the unified manager certificate layout (root:wazuh-manager 0640, dir 1770) |
 | [#2533](https://github.com/wazuh/wazuh-docker/pull/2533) | Fix bumper workflow failure when bump produces no changes |
 | [#2477](https://github.com/wazuh/wazuh-docker/issues/2477) | Bumper script issue when the tag is set to false |
 | [#2443](https://github.com/wazuh/wazuh-docker/issues/2443) | Fix reported WF vulnerabilities |

--- a/build-docker-images/wazuh-manager/Dockerfile
+++ b/build-docker-images/wazuh-manager/Dockerfile
@@ -43,8 +43,8 @@ RUN dnf install openssl findutils procps shadow-utils -y && \
     chown root:wazuh-manager /var/wazuh-manager/var/multigroups && \
     chmod 770 /var/wazuh-manager/var/multigroups && \
     mkdir -p /var/wazuh-manager/etc/certs && \
-    chown wazuh-manager:wazuh-manager /var/wazuh-manager/etc/certs && \
-    chmod 500 /var/wazuh-manager/etc/certs && \
+    chown root:wazuh-manager /var/wazuh-manager/etc/certs && \
+    chmod 1770 /var/wazuh-manager/etc/certs && \
     rm -f /var/wazuh-manager/etc/sslmanager.key && \
     rm -f /var/wazuh-manager/etc/sslmanager.cert
 

--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - master-wazuh-queue:/var/wazuh-manager/queue
       - master-wazuh-var-multigroups:/var/wazuh-manager/var/multigroups
       - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem
-      - ./config/wazuh_master/certs/wazuh.master.pem:/var/wazuh-manager/etc/certs/manager.pem
-      - ./config/wazuh_master/certs/wazuh.master-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
+      - ./config/wazuh_master/certs/wazuh.master.pem:/var/wazuh-manager/etc/certs/indexer-connector.pem
+      - ./config/wazuh_master/certs/wazuh.master-key.pem:/var/wazuh-manager/etc/certs/indexer-connector-key.pem
 
   wazuh.worker:
     image: wazuh/wazuh-manager:5.0.0
@@ -79,8 +79,8 @@ services:
       - worker-wazuh-queue:/var/wazuh-manager/queue
       - worker-wazuh-var-multigroups:/var/wazuh-manager/var/multigroups
       - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem
-      - ./config/wazuh_worker/certs/wazuh.worker.pem:/var/wazuh-manager/etc/certs/manager.pem
-      - ./config/wazuh_worker/certs/wazuh.worker-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
+      - ./config/wazuh_worker/certs/wazuh.worker.pem:/var/wazuh-manager/etc/certs/indexer-connector.pem
+      - ./config/wazuh_worker/certs/wazuh.worker-key.pem:/var/wazuh-manager/etc/certs/indexer-connector-key.pem
 
   wazuh1.indexer:
     image: wazuh/wazuh-indexer:5.0.0

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - wazuh_queue:/var/wazuh-manager/queue
       - wazuh_var_multigroups:/var/wazuh-manager/var/multigroups
       - ./config/root-ca/certs/root-ca.pem:/var/wazuh-manager/etc/certs/root-ca.pem
-      - ./config/wazuh_manager/certs/wazuh.manager.pem:/var/wazuh-manager/etc/certs/manager.pem
-      - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/manager-key.pem
+      - ./config/wazuh_manager/certs/wazuh.manager.pem:/var/wazuh-manager/etc/certs/indexer-connector.pem
+      - ./config/wazuh_manager/certs/wazuh.manager-key.pem:/var/wazuh-manager/etc/certs/indexer-connector-key.pem
 
   wazuh.indexer:
     image: wazuh/wazuh-indexer:5.0.0

--- a/tools/utils/deployment/certificates-conf.sh
+++ b/tools/utils/deployment/certificates-conf.sh
@@ -139,9 +139,9 @@ if $DO_PRIV; then
 
   for node in "${MANAGER_NODES[@]}"; do
     dir_name=$(node_to_dir "$node")
-    echo "Setting permissions for manager $node (${WAZUH_UID}:${WAZUH_GID})"
-    chown -R ${WAZUH_UID}:${WAZUH_GID} "./config/$dir_name/certs"
-    chmod 400 "./config/$dir_name/certs/"*
+    echo "Setting permissions for manager $node (0:${WAZUH_GID})"
+    chown -R 0:${WAZUH_GID} "./config/$dir_name/certs"
+    chmod 640 "./config/$dir_name/certs/"*
   done
 
   for node in "${DASHBOARD_NODES[@]}"; do
@@ -150,9 +150,9 @@ if $DO_PRIV; then
     chown -R ${WAZUH_UID}:${WAZUH_GID} "./config/$dir_name/certs"
     chmod 400 "./config/$dir_name/certs/"*
   done
-  echo "Setting permissions for root-ca certificates (${WAZUH_UID}:${WAZUH_GID})"
-  chown -R ${WAZUH_UID}:${WAZUH_GID} "./config/root-ca/certs"
-  chmod 400 "./config/root-ca/certs/"*
+  echo "Setting permissions for root-ca certificates (0:${WAZUH_GID})"
+  chown -R 0:${WAZUH_GID} "./config/root-ca/certs"
+  chmod 640 "./config/root-ca/certs/"*
 fi
 
 echo "Process completed."


### PR DESCRIPTION
## Related Issue : #2584 

## Problem 

The Wazuh manager unified all its certificates under `etc/certs` (relative to the install dir, i.e. `/var/wazuh-manager/etc/certs`) and now applies ownership by role (design: wazuh/wazuh#38281, implementation: wazuh/wazuh#38278). This repository provisions the manager's certificates and needed to be updated to match:

- **Indexer trust material** (`root-ca.pem`, `indexer-connector.pem`, `indexer-connector-key.pem`): owner `root:wazuh-manager`, mode `0640`. The manager reads this after dropping privileges but must not be able to replace its own trust anchor.
- **Self-generated server certificates** (`authd.*`, `remoted.*`, `apid.*`): owner `wazuh-manager:wazuh-manager`, mode `0640` (generated by the daemons themselves — unaffected by this PR).
- **Directory `etc/certs`**: owner `root:wazuh-manager`, mode `1770` (sticky), to support the mixed ownership above.

Two things needed to change here:
1. **Naming**: the manager's indexer client certificate is now `indexer-connector.pem`/`indexer-connector-key.pem` (was `manager.pem`/`manager-key.pem`).
2. **Ownership and modes**: wherever this repo set the manager's indexer-trust certs to `wazuh-manager:wazuh-manager`/`root:root` with owner-only modes, it now leaves them as `root:wazuh-manager 0640`, and the `etc/certs` directory as `root:wazuh-manager 1770`.

## Changes

- **`build-docker-images/wazuh-manager/Dockerfile`**: `etc/certs` directory creation changed from `chown wazuh-manager:wazuh-manager` + `chmod 500` to `chown root:wazuh-manager` + `chmod 1770`. This is a multi-stage Dockerfile; only the `builder` stage needed the change, since the final stage uses `COPY --from=builder`, which preserves ownership.

- **`single-node/docker-compose.yml`** and **`multi-node/docker-compose.yml`** (both `wazuh.master` and `wazuh.worker` services): renamed the bind-mount destination inside the manager container from `manager.pem`/`manager-key.pem` to `indexer-connector.pem`/`indexer-connector-key.pem`. The source file names on the host side (`wazuh.manager.pem`, etc. — the indexer cert generator's own naming convention) are unrelated to this issue and were left untouched.

- **`tools/utils/deployment/certificates-conf.sh`**: for the `MANAGER_NODES` and `root-ca` blocks only, changed host-side ownership/mode from `${WAZUH_UID}:${WAZUH_GID} 400` to `0:${WAZUH_GID} 640`. Verified this is safe for the shared `root-ca.pem` file (bind-mounted into manager, indexer, and dashboard): all three images use the same GID (`101`) for their respective service users, even though the group names differ, so changing the owning user to `root` doesn't affect group-readability for indexer or dashboard. The `INDEXER_NODES` and `DASHBOARD_NODES` blocks were **not** touched — those certs belong to their own services and are out of scope here. No recursive `chown -R` was introduced or changed in a way that could affect `authd.*`/`remoted.*`/`apid.*`; those are generated and owned by the manager daemons themselves and are untouched by this repo's tooling entirely.


## Validation

Deployed a real single-node stack on AWS (via `workflow_dispatch` on `5_check_integration_tools.yml`, building the manager image from this branch) and confirmed:

**Functional health** — 12 integration tests run, 11 passed, 1 skipped (unrelated: a revision-check test with no revision commands configured):

Status: PASS 🟢
Total Tests: 12 | Passed: 11 | Failed: 0 | Skipped: 1


**Explicit ownership/mode evidence** (`ls -ld` / `ls -la` on `/var/wazuh-manager/etc/certs` inside the running manager container):

```
drwxrwx--T 2 root wazuh-manager 4096 Aug 18 13:08 /var/wazuh-manager/etc/certs

-rw-r----- 1 wazuh-manager wazuh-manager 1704 apid-key.pem
-rw-r----- 1 wazuh-manager wazuh-manager 1233 apid.pem
-rw-r----- 1 wazuh-manager wazuh-manager 1704 authd-key.pem
-rw-r----- 1 wazuh-manager wazuh-manager 1261 authd.pem
-rw-r----- 1 root wazuh-manager 1708 indexer-connector-key.pem
-rw-r----- 1 root wazuh-manager 1298 indexer-connector.pem
-rw-r----- 1 wazuh-manager wazuh-manager 1704 remoted-key.pem
-rw-r----- 1 wazuh-manager wazuh-manager 1261 remoted.pem
-rw-r----- 1 root wazuh-manager 1204 root-ca.pem
```
Every value matches the layout specified in #2584:
| Item | Expected | Observed |
|---|---|---|
| `etc/certs` dir | `root:wazuh-manager 1770` | ✅ |
| `root-ca.pem` | `root:wazuh-manager 0640` | ✅ |
| `indexer-connector.pem` / `-key.pem` | `root:wazuh-manager 0640` | ✅ |
| `authd.*` / `remoted.*` / `apid.*` | `wazuh-manager:wazuh-manager 0640` | ✅ |

This evidence was captured by temporarily adding an explicit `certificates-conf.sh --priv` call plus an `ls`-based verification step to the integration test workflow, on this branch only; both were removed before requesting review (see side finding below on why `--priv` had to be added explicitly).