### PR TITLE
[DO NOT MERGE] Demo — CodeBuild runtime-versions fix for Python 3.12

### DIFF
--- a/.github/workflows/demo_codebuild_devops_vpn_amd.yml
+++ b/.github/workflows/demo_codebuild_devops_vpn_amd.yml
@@ -1,0 +1,20 @@
+name: "[DEMO] CodeBuild VPN-AMD Python 3.12 check"
+run-name: Demo - Check if devops-vpn-amd also has working Python 3.12 via runtime-versions
+
+on:
+  push:
+    branches:
+      - demo/codebuild-python312-runtime-fix
+
+jobs:
+  check:
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-vpn-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
+    steps:
+      - name: Show Python version and pip status after runtime-versions override
+        run: |
+          echo "--- python3 --version ---"
+          python3 --version
+          echo "--- python3 -m pip --version ---"
+          python3 -m pip --version || echo "pip still not available"

--- a/.github/workflows/demo_codebuild_manual_pip_bootstrap.yml
+++ b/.github/workflows/demo_codebuild_manual_pip_bootstrap.yml
@@ -1,0 +1,39 @@
+name: "[DEMO] Manual pip bootstrap on CodeBuild (Option 4)"
+run-name: Demo - Allocator install via manual pip bootstrap
+
+on:
+  push:
+    branches:
+      - demo/codebuild-python312-runtime-fix
+
+jobs:
+  check:
+    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout wazuh/wazuh-automation
+        uses: actions/checkout@v4
+        with:
+          repository: wazuh/wazuh-automation
+          ref: 'enhancement/2842-refactor-allocator-as-a-python-package-for-improved-dependency-management'
+          token: ${{ secrets.GH_CLONE_TOKEN }}
+          path: wazuh-automation
+
+      - name: Manually bootstrap pip on the default (incomplete) python3.12
+        run: |
+          echo "--- default python3.12 --version ---"
+          python3.12 --version
+          echo "--- trying ensurepip (expected to fail, module missing) ---"
+          python3.12 -m ensurepip --upgrade || echo "ensurepip failed as expected"
+          echo "--- falling back to get-pip.py ---"
+          curl -sS https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+          python3.12 /tmp/get-pip.py --break-system-packages
+          python3.12 -m pip --version
+
+      - name: Install the Allocator package with the manually bootstrapped pip
+        run: |
+          python3.12 -m pip install --break-system-packages ./wazuh-automation/deployability/modules/allocation
+
+      - name: Verify wazuh-allocator entry point exists
+        run: |
+          which wazuh-allocator || echo "wazuh-allocator entry point NOT found on PATH"
+          wazuh-allocator --help || echo "wazuh-allocator did not run successfully"

--- a/.github/workflows/demo_codebuild_python312_fix.yml
+++ b/.github/workflows/demo_codebuild_python312_fix.yml
@@ -20,6 +20,8 @@ jobs:
           which python3
           echo "--- python3 -m pip --version ---"
           python3 -m pip --version || echo "pip still not available"
+          echo "--- all pyenv versions available on this image ---"
+          pyenv versions || echo "pyenv command not found"
 
       - name: Checkout wazuh/wazuh-automation
         uses: actions/checkout@v4

--- a/.github/workflows/demo_codebuild_python312_fix.yml
+++ b/.github/workflows/demo_codebuild_python312_fix.yml
@@ -1,0 +1,39 @@
+name: "[DEMO] CodeBuild Python 3.12 runtime-versions fix"
+run-name: Demo - Allocator install with buildspec-override + runtime-versions
+
+on:
+  push:
+    branches:
+      - demo/codebuild-python312-runtime-fix
+
+jobs:
+  check:
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
+    steps:
+      - name: Show Python version and pip status after runtime-versions override
+        run: |
+          echo "--- python3 --version ---"
+          python3 --version
+          echo "--- which python3 ---"
+          which python3
+          echo "--- python3 -m pip --version ---"
+          python3 -m pip --version || echo "pip still not available"
+
+      - name: Checkout wazuh/wazuh-automation
+        uses: actions/checkout@v4
+        with:
+          repository: wazuh/wazuh-automation
+          ref: 'enhancement/2842-refactor-allocator-as-a-python-package-for-improved-dependency-management'
+          token: ${{ secrets.GH_CLONE_TOKEN }}
+          path: wazuh-automation
+
+      - name: Install the Allocator package using runtime-versions Python
+        run: |
+          python3 -m pip install --break-system-packages ./wazuh-automation/deployability/modules/allocation
+
+      - name: Verify wazuh-allocator entry point exists
+        run: |
+          which wazuh-allocator || echo "wazuh-allocator entry point NOT found on PATH"
+          wazuh-allocator --help || echo "wazuh-allocator did not run successfully"

--- a/.github/workflows/demo_codebuild_python312_fix.yml
+++ b/.github/workflows/demo_codebuild_python312_fix.yml
@@ -23,6 +23,16 @@ jobs:
           echo "--- all pyenv versions available on this image ---"
           pyenv versions || echo "pyenv command not found"
 
+      - name: Check if switching to another pre-installed version also has working pip
+        run: |
+          echo "--- switching to 3.10.20 via pyenv ---"
+          pyenv global 3.10.20
+          python3 --version
+          python3 -m pip --version || echo "pip NOT available on 3.10.20"
+          echo "--- switching back to 3.12.13 ---"
+          pyenv global 3.12.13
+          python3 --version
+
       - name: Checkout wazuh/wazuh-automation
         uses: actions/checkout@v4
         with:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,5 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      python: 3.12


### PR DESCRIPTION
⚠️ **This PR is a demonstration only and will never be merged.** 

## Option 2 — `runtime-versions` in buildspec + `buildspec-override:true`

The `standard:8.0` image (used by our `devops-amd` CodeBuild project) already ships a complete Python 3.12 with working pip — but only when explicitly requested via `runtime-versions` in a buildspec, with `buildspec-override:true` set on `runs-on`.

Run: https://github.com/wazuh/wazuh-docker/actions/runs/32475030103/job/96749491496 — Success, 32s. `pip 26.0.1` available immediately, no manual bootstrap needed.

## Option 4 — manual pip bootstrap (fallback, no image/buildspec changes needed)

Without the override, the default `python3.12` on PATH is missing `pip`/`ensurepip`. Bootstrapping via `get-pip.py --break-system-packages` works too.

Run: https://github.com/wazuh/wazuh-docker/actions/runs/32476770746/job/96754634544 — Success, 26s. `ensurepip` fails as expected, `get-pip.py` succeeds, Allocator installs correctly.

## Comparison

- **Option 2** is cleaner but activates CodeBuild's buildspec mechanism (`buildspec-override:true`), which none of our 16 current `devops-amd` workflows use today.
- **Option 4** needs more steps per workflow, but doesn't touch the CodeBuild project configuration at all — just workflow-level commands.


## Related to 
[wazuh-automation#3722.](https://github.com/wazuh/wazuh-automation/issues/3722)