### PR TITLE
Install diffutils in Wazuh agent image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 | Issue | Comment |
 | - | - |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
+| [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |
 | [#2590](https://github.com/wazuh/wazuh-docker/issues/2590) | Restore `WAZUH_MANAGER_PORT` support in the Wazuh agent image and document the enrollment variables removed in 5.0.0 |
 | [#2578](https://github.com/wazuh/wazuh-docker/issues/2578) | Report skipped bumps in the repository bumper workflow |
 | [#2584](https://github.com/wazuh/wazuh-docker/issues/2584) | Adapt certificate deployment to the unified manager certificate layout (root:wazuh-manager 0640, dir 1770) |

--- a/build-docker-images/wazuh-agent/Dockerfile
+++ b/build-docker-images/wazuh-agent/Dockerfile
@@ -77,7 +77,7 @@ ARG WAZUH_GID=101
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # Install only runtime dependencies
-RUN dnf install procps shadow-utils -y && \
+RUN dnf install diffutils procps shadow-utils -y && \
     dnf clean all && \
     getent group wazuh || groupadd -r -g ${WAZUH_GID} wazuh && \
     getent passwd wazuh || useradd --system \


### PR DESCRIPTION
## Description

Install `diffutils` in the Wazuh agent runtime image so FIM `report_changes` can execute `/usr/bin/diff`.

Update the 5.0.0 changelog with the fix.

Closes #2594

## Testing

- Rebuilt the PR branch from the current `5.0.0` head so the diff is limited to the runtime dependency and changelog entry.
- Validated the changelog entry against the repository workflow format and ran `git diff --check`.
- Previously built the complete Wazuh agent image with the 5.0.0-beta4 RPM and verified the final runtime image contains `/usr/bin/diff`, `diffutils-3.8-1.amzn2023.0.2.x86_64`, and GNU diff 3.8.
- The package installation step was also confirmed on amd64 and arm64 during review.

A fresh complete build from the rebuilt branch could not be run locally because the Docker Desktop backend fails before starting the engine.