### PR TITLE
Added diffutils to the Wazuh agent image so FIM report_changes can generate content diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 | Issue | Comment |
 | - | - |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
+| [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |
 | [#2590](https://github.com/wazuh/wazuh-docker/issues/2590) | Restore `WAZUH_MANAGER_PORT` support in the Wazuh agent image and document the enrollment variables removed in 5.0.0 |
 | [#2578](https://github.com/wazuh/wazuh-docker/issues/2578) | Report skipped bumps in the repository bumper workflow |
 | [#2584](https://github.com/wazuh/wazuh-docker/issues/2584) | Adapt certificate deployment to the unified manager certificate layout (root:wazuh-manager 0640, dir 1770) |

--- a/build-docker-images/wazuh-agent/Dockerfile
+++ b/build-docker-images/wazuh-agent/Dockerfile
@@ -77,7 +77,7 @@ ARG WAZUH_GID=101
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
 # Install only runtime dependencies
-RUN dnf install procps shadow-utils -y && \
+RUN dnf install diffutils procps shadow-utils -y && \
     dnf clean all && \
     getent group wazuh || groupadd -r -g ${WAZUH_GID} wazuh && \
     getent passwd wazuh || useradd --system \


### PR DESCRIPTION
Related issue  #2594


Cherry-picked the original commit (`a1948860`) to preserve authorship —
this PR contains no changes beyond what #2602 already proposed and
what was already reviewed/validated on this issue.

## Fix

`diffutils` added to the Wazuh agent image's runtime dependencies, so
`/usr/bin/diff` is available for FIM's `report_changes` feature.

## Validation (already done on #2594/#2602)

- Confirmed `diffutils` installs correctly on both architectures
  (verified via the `dnf` transaction log during a build with this
  change).
- Measured image size impact: ~1.4 MB installed size increase per
  architecture (6.7 MB → 8.1 MB), negligible against the ~191 MB
  (amd64) / ~228 MB (arm64) total agent image size.