### PR TITLE
Default WAZUH_CLUSTER_BIND_ADDR to 0.0.0.0 so the published manager image actually starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2634](https://github.com/wazuh/wazuh-docker/issues/2634) | Default WAZUH_CLUSTER_BIND_ADDR to 0.0.0.0 so the published manager image actually starts |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
 | [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |
 | [#2590](https://github.com/wazuh/wazuh-docker/issues/2590) | Restore `WAZUH_MANAGER_PORT` support in the Wazuh agent image and document the enrollment variables removed in 5.0.0 |

--- a/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init
+++ b/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init
@@ -313,6 +313,7 @@ sed -i "/<cluster>/,/<\/cluster>/ s|<key>.*</key>|<key>$WAZUH_CLUSTER_KEY</key>|
 # --------------------------
 # Cluster: bind_addr
 # --------------------------
+WAZUH_CLUSTER_BIND_ADDR="${WAZUH_CLUSTER_BIND_ADDR:-0.0.0.0}"
 sed -i "/<cluster>/,/<\/cluster>/ s|<bind_addr>.*</bind_addr>|<bind_addr>$WAZUH_CLUSTER_BIND_ADDR</bind_addr>|" "$WAZUH_MANAGER_CONF"
 
 # --------------------------


### PR DESCRIPTION
## Related Issue #2634 


## Description 

`0-wazuh-init` substitutes `WAZUH_CLUSTER_BIND_ADDR` into `<cluster><bind_addr>`, but unlike its sibling `WAZUH_REMOTE_BIND_ADDR` (already defaulted to `0.0.0.0` at line 293), it never gets a default
anywhere in the script. A plain `docker run` with no environment variables leaves it unset, so the substitution writes an empty `<bind_addr>`, which the manager's config schema rejects (`minLength` violation) — every daemon fails to start.

The failure is silent: the entrypoint runs `tail -F` on the log afterward regardless of whether the manager started, so the container stays `Up` and looks healthy to any orchestrator.

## Fix

Same one-line pattern already used for the sibling variable:
```bash
WAZUH_CLUSTER_BIND_ADDR="${WAZUH_CLUSTER_BIND_ADDR:-0.0.0.0}"
```
Added right before the `<bind_addr>` substitution, matching the issue's suggested fix exactly.

## Validation

Reproduced the exact scenario from the issue's "Reproducing" section,patching a local build of `wazuh-manager:5.0.0-latest` with this change:

| | Before (official image) | After (this fix) |
|---|---|---|
| Container status | `running` | `running` |
| `wazuh-manager` daemons alive | 0 | 2 |
| Error 1244 in logs | present | absent |


```
$ docker logs probe_before 2>&1 | grep -E '1244|Configuration error' (1244): Invalid configuration at '/cluster/bind_addr': does not satisfy 'minLength' [schema /properties/cluster/properties/bind_addr].
wazuh-manager.conf: Configuration error. Exiting

$ docker logs probe_after 2>&1 | grep -E '1244|Configuration error'
(no output)
```

## Additional validation — full image build from source

Also validated with a complete build from the Dockerfile (not just a
patch over the published image), using real RPM artifacts via
`artifact_urls.yaml` + `build-images.sh -c wazuh-manager -v 5.0.0`:

```
$ docker run -d --name probe_real_build wazuh/wazuh-manager:5.0.0
$ sleep 45 && docker inspect -f '{{.State.Status}}' probe_real_build
running
$ docker exec probe_real_build sh -c 'ps -eo comm | grep -c wazuh-manager'
2
$ docker logs probe_real_build 2>&1 | grep -E '1244|Configuration error'
(no output)
```


Same result as the earlier patched-image validation — 2 daemons alive,
no config errors