### PR TITLE
Use wazuh-manager-control's own exit code in single-node healthcheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 | Issue | Comment |
 | - | - |
-| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now uses the command's own exit code instead of grepping for 'not running', catching all failure states |
+| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now catches all failure states, not just 'not running': single-node and the cluster master use the command's own exit code, and the worker checks for all known failure strings instead of just one |
 
 ## Prior versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now uses the command's own exit code instead of grepping for 'not running', catching all failure states |
 
 ## Prior versions
 

--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       wazuh1.indexer:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -q 'not running' && exit 1 || exit 0" ]
+      test: [ "CMD", "/var/wazuh-manager/bin/wazuh-manager-control", "status" ]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -49,7 +49,7 @@ services:
     container_name: multi-node-wazuh.worker
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -v apid | grep -q 'not running' && exit 1 || exit 0" ]
+      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -v apid | grep -qE 'not running|failed to start|refused its configuration' && exit 1 || exit 0" ]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       wazuh.indexer:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -q 'not running' && exit 1 || exit 0" ]
+      test: [ "CMD", "/var/wazuh-manager/bin/wazuh-manager-control", "status" ]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Changes
 
**single-node and the cluster master:** `wazuh-manager-control status` already sets the correct exit code for all these failure states on its own. So instead of grepping the text, I now just run the command directly and let Docker read its exit code.
 
**cluster worker:** this one couldn't get the same simple fix. The worker's healthcheck has an extra piece: it filters out any line mentioning `apid` before checking for failures (`grep -v apid`). That's intentional — `apid` is only supposed to run on the master, so on the worker it will always show as "not running", and that's normal, not a failure.
 
If I switched the worker to the raw exit code like I did for the master, I'd lose that filtering. The exit code reflects the state of every daemon at once, `apid` included, so the worker would end up permanently marked `unhealthy` for something that's expected behavior.
 
So for the worker, I kept the text-based grep, but fixed the actual bug: instead of only checking for `not running`, it now checks for all three known failure phrases.
 
## Verification
 
I couldn't spin up a real `5.1.0` stack to test end-to-end — neither the Docker image nor the certificate-generation scripts for that version are published yet. Instead, I tested the exact logic with a stand-in script that reproduces the same outputs `wazuh-manager-control status` can give, and ran the real healthcheck commands against it.
 
**single-node / master**, comparing the old logic against the new one for every possible state:
 
```
=== OLD logic, state=healthy ===
RESULT: exit 0 (healthy)
=== OLD logic, state=not_running ===
RESULT: exit 1 (unhealthy)
=== OLD logic, state=failed_to_start ===
RESULT: exit 0 (healthy)          <- bug: should be unhealthy
=== OLD logic, state=refused_config ===
RESULT: exit 0 (healthy)          <- bug: should be unhealthy
 
=== NEW logic, state=healthy ===
RESULT: exit 0 (healthy)
=== NEW logic, state=not_running ===
RESULT: exit 1 (unhealthy)
=== NEW logic, state=failed_to_start ===
RESULT: exit 1 (unhealthy)        <- fixed
=== NEW logic, state=refused_config ===
RESULT: exit 1 (unhealthy)        <- fixed
```
 
**worker**, confirming the apid exclusion still works and the missed failure states are now caught:
 
```
=== WORKER logic (new), state=healthy (apid reported "not running", as expected) ===
RESULT: exit 0 (healthy)          <- apid exclusion still works correctly
=== WORKER logic (new), state=not_running ===
RESULT: exit 1 (unhealthy)
=== WORKER logic (new), state=failed_to_start ===
RESULT: exit 1 (unhealthy)        <- previously a false healthy
```
