### PR TITLE
Fix manager and dashboard healthchecks to correctly detect failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Added
 
-
 | Issue | Comment |
 | - | - |
 | [#2606](https://github.com/wazuh/wazuh-docker/issues/2606) | Support the unified `WAZUH_MANAGER_ENDPOINT` connection URL in the Wazuh agent, alongside `WAZUH_MANAGER_SERVER` and `WAZUH_MANAGER_PORT` |
@@ -15,7 +14,6 @@
 | [#2276](https://github.com/wazuh/wazuh-docker/issues/2276) | Add `--set-as-main` flag support to repository bumper — `wazuh-docker` |
 
 ### Changed
-
 
 | Issue | Comment |
 | - | - |
@@ -75,10 +73,9 @@
 
 ### Fixed
 
-
 | Issue | Comment |
 | - | - |
-| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now uses the command's own exit code instead of grepping for 'not running', catching all failure states |
+| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now catches all failure states, not just 'not running': single-node and the cluster master use the command's own exit code, and the worker checks for all known failure strings instead of just one |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
 | [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |
 | [#2590](https://github.com/wazuh/wazuh-docker/issues/2590) | Restore `WAZUH_MANAGER_PORT` support in the Wazuh agent image and document the enrollment variables removed in 5.0.0 |
@@ -95,6 +92,7 @@
 | [#2271](https://github.com/wazuh/wazuh-docker/issues/2271) | Wazuh manager Healthcheck |
 | [#2258](https://github.com/wazuh/wazuh-docker/issues/2258) | Delete WAZUH_AGENT_GROUPS of Wazuh 5.0.0 images build |
 | [#2128](https://github.com/wazuh/wazuh-docker/issues/2128) | Development - DevOps 5.0 adaptation - Docker - Delete lists directory references |
+
 
 ## Prior versions
 - []()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now uses the command's own exit code instead of grepping for 'not running', catching all failure states |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
 | [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |
 | [#2590](https://github.com/wazuh/wazuh-docker/issues/2590) | Restore `WAZUH_MANAGER_PORT` support in the Wazuh agent image and document the enrollment variables removed in 5.0.0 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@
 
 | Issue | Comment |
 | - | - |
-| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Manager healthcheck now catches all failure states, not just 'not running': single-node and the cluster master use the command's own exit code, and the worker checks for all known failure strings instead of just one |
+| [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Fixed manager and dashboard healthchecks to correctly detect failures instead of always reporting healthy |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
 | [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |
 | [#2590](https://github.com/wazuh/wazuh-docker/issues/2590) | Restore `WAZUH_MANAGER_PORT` support in the Wazuh agent image and document the enrollment variables removed in 5.0.0 |

--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       wazuh1.indexer:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -q 'not running' && exit 1 || exit 0" ]
+      test: [ "CMD", "/var/wazuh-manager/bin/wazuh-manager-control", "status" ]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -49,7 +49,7 @@ services:
     container_name: multi-node-wazuh.worker
     restart: always
     healthcheck:
-      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -v apid | grep -q 'not running' && exit 1 || exit 0" ]
+      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -v apid | grep -qE 'not running|failed to start|refused its configuration' && exit 1 || exit 0" ]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/multi-node/docker-compose.yml
+++ b/multi-node/docker-compose.yml
@@ -202,7 +202,7 @@ services:
     container_name: multi-node-wazuh.dashboard
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-k", "-s", "-o", "/dev/null", "https://localhost:5601/login" ]
+      test: [ "CMD", "curl", "-f", "-k", "-s", "-o", "/dev/null", "https://localhost:5601/app/login" ]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       wazuh.indexer:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD-SHELL", "/var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null | grep -q 'not running' && exit 1 || exit 0" ]
+      test: [ "CMD", "/var/wazuh-manager/bin/wazuh-manager-control", "status" ]
       interval: 15s
       timeout: 5s
       retries: 5

--- a/single-node/docker-compose.yml
+++ b/single-node/docker-compose.yml
@@ -87,7 +87,7 @@ services:
     container_name: single-node-wazuh.dashboard
     restart: always
     healthcheck:
-      test: [ "CMD", "curl", "-k", "-s", "-o", "/dev/null", "https://localhost:5601/login" ]
+      test: [ "CMD", "curl", "-f", "-k", "-s", "-o", "/dev/null", "https://localhost:5601/app/login" ]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Manager healthcheck
 
**single-node and the cluster master:** `wazuh-manager-control status` already sets the correct exit code for all these failure states on its own. So instead of grepping the text, I now just run the command directly and let Docker read its exit code.
 
**cluster worker:** this one couldn't get the same simple fix. The worker's healthcheck has an extra piece: it filters out any line mentioning `apid` before checking for failures (`grep -v apid`). That's intentional — `apid` is only supposed to run on the master, so on the worker it will always show as "not running", and that's normal, not a failure.
 
If I switched the worker to the raw exit code like I did for the master, I'd lose that filtering. The exit code reflects the state of every daemon at once, `apid` included, so the worker would end up permanently marked `unhealthy` for something that's expected behavior.
 
So for the worker, I kept the text-based grep, but fixed the actual bug: instead of only checking for `not running`, it now checks for all three known failure phrases.
 
## Verification
 
I couldn't spin up a real `5.1.0` stack to test end-to-end — neither the Docker image nor the certificate-generation scripts for that version are published yet. Instead, I tested the exact logic with a stand-in script that reproduces the same outputs `wazuh-manager-control status` can give, and ran the real healthcheck commands against it.
 
**single-node / master**, comparing the old logic against the new one for every possible state:
 
```
=== OLD logic, state=healthy ===
RESULT: exit 0 (healthy)
=== OLD logic, state=not_running ===
RESULT: exit 1 (unhealthy)
=== OLD logic, state=failed_to_start ===
RESULT: exit 0 (healthy)          <- bug: should be unhealthy
=== OLD logic, state=refused_config ===
RESULT: exit 0 (healthy)          <- bug: should be unhealthy
 
=== NEW logic, state=healthy ===
RESULT: exit 0 (healthy)
=== NEW logic, state=not_running ===
RESULT: exit 1 (unhealthy)
=== NEW logic, state=failed_to_start ===
RESULT: exit 1 (unhealthy)        <- fixed
=== NEW logic, state=refused_config ===
RESULT: exit 1 (unhealthy)        <- fixed
```
 
**worker**, confirming the apid exclusion still works and the missed failure states are now caught:
 
```
=== WORKER logic (new), state=healthy (apid reported "not running", as expected) ===
RESULT: exit 0 (healthy)          <- apid exclusion still works correctly
=== WORKER logic (new), state=not_running ===
RESULT: exit 1 (unhealthy)
=== WORKER logic (new), state=failed_to_start ===
RESULT: exit 1 (unhealthy)        <- previously a false healthy
```


## Real container verification
 
Managed to get real `5.0.0` packages after all, so I built the images locally with `build-images.sh --dev` and ran the actual stack with `docker compose up`.
 
**Healthy case** — full stack up, manager running all 7 daemons:
 
```
$ docker ps --format "table {{.Names}}\t{{.Status}}"
NAMES                         STATUS
single-node-wazuh.dashboard   Up 34 seconds (healthy)
single-node-wazuh.manager     Up 44 seconds (healthy)
single-node-wazuh.indexer     Up About a minute (healthy)
 
$ docker exec single-node-wazuh.manager /var/wazuh-manager/bin/wazuh-manager-control status
wazuh-manager-clusterd is running...
wazuh-manager-modulesd is running...
wazuh-manager-remoted is running...
wazuh-manager-analysisd is running...
wazuh-manager-db is running...
wazuh-manager-authd is running...
wazuh-manager-apid is running...
Exit code: 0
```
 
**Failure case** — stopped the daemons for real inside the container, then waited for the healthcheck's `retries: 5` × `interval: 15s` window:
 
```
$ docker exec single-node-wazuh.manager /var/wazuh-manager/bin/wazuh-manager-control stop
Wazuh v5.0.0 Stopped
 
$ docker exec single-node-wazuh.manager /var/wazuh-manager/bin/wazuh-manager-control status
wazuh-manager-clusterd not running...
wazuh-manager-modulesd not running...
[...all 7 not running]
Exit code: 1
 
# ~90s later
$ docker inspect single-node-wazuh.manager --format='{{.State.Health.Status}}'
unhealthy
```
 
Docker correctly picked up the failure via the new healthcheck and marked the container `unhealthy`, on a real manager, not just the stand-in script from the earlier verification.