### PR TITLE
Preserve dashboard credential values during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2631](https://github.com/wazuh/wazuh-docker/issues/2631) | Preserve Wazuh dashboard credential values during configuration and keystore startup handling |
 | [#2634](https://github.com/wazuh/wazuh-docker/issues/2634) | Default WAZUH_CLUSTER_BIND_ADDR to 0.0.0.0 so the published manager image actually starts |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
 | [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |

--- a/build-docker-images/wazuh-dashboard/config/entrypoint.sh
+++ b/build-docker-images/wazuh-dashboard/config/entrypoint.sh
@@ -26,8 +26,8 @@ if  [ ! -f "$OPENSEARCH_DASHBOARDS_HOME/config/opensearch_dashboards.keystore" ]
     "$OPENSEARCH_DASHBOARDS_HOME/bin/opensearch-dashboards-keystore" create --allow-root
     head -c 32 /dev/urandom | base64 | tr -d '\n' | "$OPENSEARCH_DASHBOARDS_HOME/bin/opensearch-dashboards-keystore" add wazuh_ai_assistant.encryptionKey --stdin --allow-root
 fi
-echo $DASHBOARD_USERNAME | "$OPENSEARCH_DASHBOARDS_HOME/bin/opensearch-dashboards-keystore" add opensearch.username --stdin --allow-root -f
-echo $DASHBOARD_PASSWORD | "$OPENSEARCH_DASHBOARDS_HOME/bin/opensearch-dashboards-keystore" add opensearch.password --stdin --allow-root -f
+printf '%s\n' "$DASHBOARD_USERNAME" | "$OPENSEARCH_DASHBOARDS_HOME/bin/opensearch-dashboards-keystore" add opensearch.username --stdin --allow-root -f
+printf '%s\n' "$DASHBOARD_PASSWORD" | "$OPENSEARCH_DASHBOARDS_HOME/bin/opensearch-dashboards-keystore" add opensearch.password --stdin --allow-root -f
 
 /wazuh_dashboard_config.sh
 

--- a/build-docker-images/wazuh-dashboard/config/wazuh_dashboard_config.sh
+++ b/build-docker-images/wazuh-dashboard/config/wazuh_dashboard_config.sh
@@ -79,6 +79,14 @@ declare -A CONFIG_MAP=(
     [wazuh.monitoring.replicas]="$WAZUH_MONITORING_REPLICAS"
 )
 
+# Values used on the right-hand side of a sed substitution are sed syntax.
+# Escape them before interpolation so '&', '\\', and the chosen delimiter are
+# written literally instead of expanding the match, disappearing, or breaking
+# the substitution.
+sed_escape_replacement() {
+    printf '%s' "$1" | sed -e 's/[\\&|]/\\&/g'
+}
+
 # Replace configuration values in the dashboard config file
 for key in "${!CONFIG_MAP[@]}"; do
     value="${CONFIG_MAP[$key]}"
@@ -90,21 +98,32 @@ for key in "${!CONFIG_MAP[@]}"; do
 
     # Escape special characters for sed
     escaped_key=$(echo "$key" | sed 's/[.[\*^$()+?{|]/\\&/g')
+    escaped_value=$(sed_escape_replacement "$value")
 
     # Try to replace existing line (commented or uncommented)
     if grep -q "^[#[:space:]]*${escaped_key}:" "$DASHBOARD_CONFIG_FILE"; then
-        sed -i "s|^[#[:space:]]*${escaped_key}:.*|${key}: ${value}|" "$DASHBOARD_CONFIG_FILE"
+        sed -i "s|^[#[:space:]]*${escaped_key}:.*|${key}: ${escaped_value}|" "$DASHBOARD_CONFIG_FILE"
     fi
 done
 
 # Handle wazuh_core.hosts section separately
 if grep -q "^wazuh_core.hosts:" "$DASHBOARD_CONFIG_FILE"; then
+    escaped_wazuh_api_url=$(sed_escape_replacement "$WAZUH_API_URL")
+    escaped_api_port=$(sed_escape_replacement "$API_PORT")
+    escaped_api_username=$(sed_escape_replacement "$API_USERNAME")
+    escaped_run_as=$(sed_escape_replacement "$RUN_AS")
+
+    # A single-quoted YAML scalar keeps sed metacharacters such as backslashes
+    # literal. YAML represents a literal apostrophe inside it as two apostrophes.
+    yaml_api_password=$(printf '%s' "$API_PASSWORD" | sed "s/'/''/g")
+    escaped_api_password=$(sed_escape_replacement "$yaml_api_password")
+
     # Update existing wazuh_core.hosts section
     sed -i "/^wazuh_core.hosts:/,/^[^ ]/ {
-        s|url:.*|url: $WAZUH_API_URL|
-        s|port:.*|port: $API_PORT|
-        s|username:.*|username: $API_USERNAME|
-        s|password:.*|password: \"$API_PASSWORD\"|
-        s|run_as:.*|run_as: $RUN_AS|
+        s|url:.*|url: $escaped_wazuh_api_url|
+        s|port:.*|port: $escaped_api_port|
+        s|username:.*|username: $escaped_api_username|
+        s|password:.*|password: '$escaped_api_password'|
+        s|run_as:.*|run_as: $escaped_run_as|
     }" "$DASHBOARD_CONFIG_FILE"
 fi

--- a/tools/tests/check-dashboard-config-literals.sh
+++ b/tools/tests/check-dashboard-config-literals.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
+
+set -euo pipefail
+
+if ((BASH_VERSINFO[0] < 4)); then
+    echo "check-dashboard-config-literals: Bash 4 or newer is required" >&2
+    exit 2
+fi
+
+repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+config_script="${repo_root}/build-docker-images/wazuh-dashboard/config/wazuh_dashboard_config.sh"
+entrypoint="${repo_root}/build-docker-images/wazuh-dashboard/config/entrypoint.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+config_file="${test_dir}/opensearch_dashboards.yml"
+cat > "$config_file" <<'EOF'
+opensearch.password: old-indexer-password
+wazuh_core.hosts:
+  - default:
+      url: https://localhost
+      port: 55000
+      username: wazuh-wui
+      password: "old-api-password"
+      run_as: true
+next.section: unchanged
+EOF
+
+literal='abc&def|ghi\jkl'
+apostrophe="one'two&three|four\\five"
+
+DASHBOARD_CONFIG_FILE="$config_file" \
+OPENSEARCH_PASSWORD="$literal" \
+API_PASSWORD="$apostrophe" \
+"$BASH" "$config_script"
+
+grep -Fqx "opensearch.password: $literal" "$config_file"
+grep -Fqx "      password: 'one''two&three|four\five'" "$config_file"
+grep -Fqx 'next.section: unchanged' "$config_file"
+
+# The keystore input must be one literal shell word. Unquoted echo would fold
+# repeated whitespace and tabs before the keystore receives the credential.
+grep -Fq 'printf '\''%s\n'\'' "$DASHBOARD_USERNAME"' "$entrypoint"
+grep -Fq 'printf '\''%s\n'\'' "$DASHBOARD_PASSWORD"' "$entrypoint"
+
+echo "dashboard configuration values are preserved literally"


### PR DESCRIPTION
## Summary

Addresses the dashboard portion of #2631.

- Escape `&`, `|`, and backslash before dashboard configuration values enter the replacement side of `sed`.
- Write the API password as a single-quoted YAML scalar, including YAML-correct apostrophe doubling.
- Replace the two unquoted keystore `echo` pipelines with quoted `printf` so repeated whitespace and tabs remain literal.
- Add a focused regression script and the required changelog entry.

## Verification

- `tools/tests/check-dashboard-config-literals.sh` passes.
- In the published ARM64 `wazuh/wazuh-dashboard:5.0.0-beta5` image, the unmodified scripts failed all 10 credential-literal checks: eight configuration values plus the username and password stored in the real OpenSearch Dashboards keystore.
- The corrected current-branch scripts on that same pinned image runtime passed all 10 checks. The configuration assertions parse the generated YAML, and the keystore assertions decrypt and compare the values written by the actual entrypoint.
- Bash syntax checks, `git diff --check`, patch-application, and the repository's 5.x changelog-format check pass locally.

I did not run the full Wazuh stack or upstream CI. This patch intentionally leaves the manager and agent portions of #2631 unchanged so each image can receive format-aware tests and review.

## Credit and AI assistance

The original defect report and published-image reproductions are by Rebits. The maintainer confirmation and affected-script summary are by jotamolas.

I used an AI coding and research assistant to inspect the current branch, prepare this patch, and run the verification. I reviewed the resulting diff and evidence and am asking the Wazuh maintainers to review both the implementation and its scope.
