### PR TITLE
Validate and default WAZUH_INDEXER_HOSTS parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2630](https://github.com/wazuh/wazuh-docker/issues/2630) | Fixed WAZUH_INDEXER_HOSTS parsing: hosts without an explicit port, URLs with a scheme, and bracketed IPv6 addresses were silently mangled instead of being parsed correctly, and unparseable values were written to the config without any error |
 | [#2634](https://github.com/wazuh/wazuh-docker/issues/2634) | Default WAZUH_CLUSTER_BIND_ADDR to 0.0.0.0 so the published manager image actually starts |
 | [#2604](https://github.com/wazuh/wazuh-docker/issues/2604) | Adapt Wazuh manager image to new enroll process |
 | [#2594](https://github.com/wazuh/wazuh-docker/issues/2594) | Added `diffutils` to the Wazuh agent image so FIM `report_changes` can generate content diffs |

--- a/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init
+++ b/build-docker-images/wazuh-manager/config/etc/cont-init.d/0-wazuh-init
@@ -269,9 +269,15 @@ if [[ -n "$WAZUH_INDEXER_HOSTS" ]]; then
         echo "    <hosts>"
         IFS=',' read -ra NODES <<< "$WAZUH_INDEXER_HOSTS"
         for NODE in "${NODES[@]}"; do
-            IP="${NODE%:*}"
-            PORT="${NODE#*:}"
-            echo "      <host>https://$IP:$PORT</host>"
+            NODE="${NODE#"${NODE%%[![:space:]]*}"}"
+            NODE="${NODE#http://}"; NODE="${NODE#https://}"
+            if [[ "$NODE" == *:* ]]; then
+                HOST="${NODE%:*}"; PORT="${NODE##*:}"
+            else
+                HOST="$NODE"; PORT=9200
+            fi
+            [[ "$PORT" =~ ^[0-9]+$ ]] || { print "Invalid indexer host '$NODE'" >&2; exit 1; }
+            echo "      <host>https://${HOST}:${PORT}</host>"
         done
         echo "    </hosts>"
     } > "$TMP_HOSTS";


### PR DESCRIPTION
## Changes
Replaced the blind split with validate-and-default logic:

```bash
NODE="${NODE#"${NODE%%[![:space:]]*}"}"      # trim leading space
NODE="${NODE#http://}"; NODE="${NODE#https://}"
if [[ "$NODE" == *:* ]]; then
    HOST="${NODE%:*}"; PORT="${NODE##*:}"    # last colon, not first — fixes bracketed IPv6
else
    HOST="$NODE"; PORT=9200
fi
[[ "$PORT" =~ ^[0-9]+$ ]] || { print "Invalid indexer host '$NODE'" >&2; exit 1; }
```

An unparseable host now fails loudly (non-zero exit, clear message) instead of silently writing a broken config and reporting success.

**Extra fix found while testing:** the error message was being swallowed. The `for` loop lives inside a `{ ... } > "$TMP_HOSTS"` block, so `print`'s stdout (including the error message) was captured into the temp file instead of reaching the log — the script did exit non-zero, but "Invalid indexer host" never actually showed up anywhere. Redirected it to stderr (`>&2`) so it's visible.

## Verification

Tested all 9 cases from the issue against the real script, inside a `5.0.0` image built locally from real packages 

| Input | Result |
|---|---|
| `wazuh.indexer:9200` | `https://wazuh.indexer:9200` ✅ |
| `wazuh.indexer` (no port) | `https://wazuh.indexer:9200` ✅ |
| `https://wazuh.indexer:9200` | `https://wazuh.indexer:9200` ✅ |
| `http://wazuh.indexer:9200` | `https://wazuh.indexer:9200` ✅ |
| `n1:9200,n2:9200,n3:9200` | 3 separate `<host>` lines ✅ |
| `n1:9200, n2:9200` (space) | 2 lines, no leading space ✅ |
| `[::1]:9200` (IPv6, brackets) | `https://[::1]:9200` ✅ |
| `::1:9200` (IPv6, no brackets) | `https://::1:9200` (parsed sensibly) ✅ |
| unparseable garbage | exit 1, `Invalid indexer host '...'` printed, config left untouched ✅ |

Each case was run like this, against the real `0-wazuh-init` script inside the built image:

```bash
docker run --rm --entrypoint bash -e WAZUH_INDEXER_HOSTS="<value>" wazuh/wazuh-manager:test-indexer-parsing -c "
mkdir -p /var/wazuh-manager/etc
printf '<ossec_config>\n  <indexer>\n    <hosts>\n    </hosts>\n  </indexer>\n</ossec_config>\n' > /var/wazuh-manager/etc/wazuh-manager.conf
bash /etc/cont-init.d/0-wazuh-init 2>&1
cat /var/wazuh-manager/etc/wazuh-manager.conf
"
```