### PR TITLE
Supervise manager daemons from entrypoint and exit on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2626](https://github.com/wazuh/wazuh-docker/issues/2626) | Supervise the manager daemons from the entrypoint and exit if a critical one dies, so `restart: always` can bring the container back instead of it staying up indefinitely with a dead API |
 | [#2634](https://github.com/wazuh/wazuh-docker/issues/2634) | Default WAZUH_CLUSTER_BIND_ADDR to 0.0.0.0 so the published manager image actually starts |
 | [#2630](https://github.com/wazuh/wazuh-docker/issues/2630) | Fixed WAZUH_INDEXER_HOSTS parsing: hosts without an explicit port, URLs with a scheme, and bracketed IPv6 addresses were silently mangled instead of being parsed correctly, and unparseable values were written to the config without any error |
 | [#2627](https://github.com/wazuh/wazuh-docker/issues/2627) | Fixed manager and dashboard healthchecks to correctly detect failures instead of always reporting healthy |

--- a/build-docker-images/wazuh-manager/config/entrypoint.sh
+++ b/build-docker-images/wazuh-manager/config/entrypoint.sh
@@ -30,13 +30,15 @@ trap '_stop 0' SIGTERM SIGINT SIGQUIT
 STARTUP_GRACE_PERIOD=60
 CHECK_INTERVAL=15
 
-# Same default as cont-init.d/0-wazuh-init: master unless WAZUH_NODE_TYPE=worker
-# is set (only multi-node/docker-compose.yml's wazuh.worker service sets it).
-WAZUH_NODE_TYPE="${WAZUH_NODE_TYPE:-master}"
-
 # Same reader the core wazuh-manager-control script itself uses to decide
 # whether to start authd (start_service(), "auth.disabled: true" case).
 WAZUH_MANAGER_CONF="/var/wazuh-manager/bin/wazuh-manager-conf -H /var/wazuh-manager -f /var/wazuh-manager/etc/wazuh-manager.conf"
+
+# Timeout for each status check: wazuh-manager-control status has no upper
+# bound of its own, and a hang here would otherwise block both failure
+# detection and the SIGTERM trap below (docker stop would have to wait out
+# its own timeout and fall back to SIGKILL).
+STATUS_TIMEOUT=5
 
 # Supervise the manager: if a critical daemon is not running, exit non-zero so
 # the container dies and `restart: always` (single-node/multi-node
@@ -50,24 +52,33 @@ WAZUH_MANAGER_CONF="/var/wazuh-manager/bin/wazuh-manager-conf -H /var/wazuh-mana
 # configuration" lines, not a fragile grep on arbitrary text -- these are
 # exactly the three cases that set that script's own non-zero RETVAL.
 #
-# Two lines are excluded before matching those patterns, for daemons that
-# wazuh-manager-control deliberately never starts but that its own status()
-# does not know to exclude:
-#   - apid: only runs on the master node (same exclusion the multi-node
-#     worker healthcheck already applies with its own `grep -v apid`).
-#   - authd: skipped by start_service() when auth.disabled: true is set in
-#     wazuh-manager.conf, but status() has no matching exclusion for it --
-#     a real bug in the core script (found by Julia while reviewing this
-#     fix). Without compensating here, any deployment with
-#     auth.disabled: true would restart-loop forever.
+# No manual exclusion for apid here: status() already excludes it correctly
+# on non-master nodes by reading the real cluster.node_type from the config
+# file, unlike a naive check against the raw WAZUH_NODE_TYPE env var (which
+# an earlier version of this fix duplicated, and which broke silently on
+# case mismatches like WAZUH_NODE_TYPE=WORKER -- found by QA testing this
+# fix). Trust the same source of truth wazuh-manager-control itself uses.
+#
+# authd is excluded when auth.disabled: true is set in wazuh-manager.conf,
+# because start_service() skips starting it in that case but status() has no
+# matching exclusion for it -- a real bug in the core script (found by Julia
+# while reviewing this fix). Without compensating here, any deployment with
+# auth.disabled: true would restart-loop forever.
 _manager_unhealthy() {
     exclude_pattern='^$'
-    [ "${WAZUH_NODE_TYPE}" != "master" ] && exclude_pattern="${exclude_pattern}|apid"
     if [ "$(${WAZUH_MANAGER_CONF} get auth.disabled 2>/dev/null)" = "true" ]; then
         exclude_pattern="${exclude_pattern}|authd"
     fi
 
-    /var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null \
+    local status_output status_rc
+    status_output="$(timeout "${STATUS_TIMEOUT}" /var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null)"
+    status_rc=$?
+    # timeout's own exit code for "killed the command because it ran too
+    # long" is 124 -- treat a hung status check as unhealthy rather than
+    # letting the empty output silently read as "no failures found".
+    [ "${status_rc}" -eq 124 ] && return 0
+
+    echo "${status_output}" \
         | grep -vE "${exclude_pattern}" \
         | grep -qE 'not running|failed to start|refused its configuration'
 }

--- a/build-docker-images/wazuh-manager/config/entrypoint.sh
+++ b/build-docker-images/wazuh-manager/config/entrypoint.sh
@@ -11,12 +11,75 @@ bash /etc/cont-init.d/1-manager
 tail -F /var/wazuh-manager/logs/wazuh-manager.log &
 TAIL_PID=$!
 
-# Graceful shutdown: stop Wazuh and exit cleanly on SIGTERM/SIGINT
+# Stop Wazuh and the log tail. Used both for a graceful shutdown (SIGTERM/
+# SIGINT/SIGQUIT, exit 0) and when supervision below detects a dead/broken
+# daemon (exit 1, so the failure is visible in `docker inspect` and any
+# restart policy other than "always" would still react correctly).
 _stop() {
+    exit_code="${1:-0}"
     echo "Stopping Wazuh Manager..."
     /var/wazuh-manager/bin/wazuh-manager-control stop 2>/dev/null || true
     kill "${TAIL_PID}" 2>/dev/null || true
+    exit "${exit_code}"
 }
-trap _stop SIGTERM SIGINT SIGQUIT
+trap '_stop 0' SIGTERM SIGINT SIGQUIT
+
+# Grace period before the first supervision check: mirrors the compose
+# healthcheck's own start_period (60s), so we don't kill the container while
+# the manager daemons are still coming up.
+STARTUP_GRACE_PERIOD=60
+CHECK_INTERVAL=15
+
+# Same default as cont-init.d/0-wazuh-init: master unless WAZUH_NODE_TYPE=worker
+# is set (only multi-node/docker-compose.yml's wazuh.worker service sets it).
+WAZUH_NODE_TYPE="${WAZUH_NODE_TYPE:-master}"
+
+# Same reader the core wazuh-manager-control script itself uses to decide
+# whether to start authd (start_service(), "auth.disabled: true" case).
+WAZUH_MANAGER_CONF="/var/wazuh-manager/bin/wazuh-manager-conf -H /var/wazuh-manager -f /var/wazuh-manager/etc/wazuh-manager.conf"
+
+# Supervise the manager: if a critical daemon is not running, exit non-zero so
+# the container dies and `restart: always` (single-node/multi-node
+# docker-compose.yml) actually gets a chance to bring it back. Without this,
+# tail -F never exits on its own regardless of what happens to the daemons
+# started by wazuh-manager-control (see wazuh-docker#2626), so the container
+# stays "Up" forever with a dead API/daemon and no restart is ever triggered.
+#
+# Same failure vocabulary as the compose healthchecks (fixed in #2642):
+# wazuh-manager-control status's "not running"/"failed to start"/"refused its
+# configuration" lines, not a fragile grep on arbitrary text -- these are
+# exactly the three cases that set that script's own non-zero RETVAL.
+#
+# Two lines are excluded before matching those patterns, for daemons that
+# wazuh-manager-control deliberately never starts but that its own status()
+# does not know to exclude:
+#   - apid: only runs on the master node (same exclusion the multi-node
+#     worker healthcheck already applies with its own `grep -v apid`).
+#   - authd: skipped by start_service() when auth.disabled: true is set in
+#     wazuh-manager.conf, but status() has no matching exclusion for it --
+#     a real bug in the core script (found by Julia while reviewing this
+#     fix). Without compensating here, any deployment with
+#     auth.disabled: true would restart-loop forever.
+_manager_unhealthy() {
+    exclude_pattern='^$'
+    [ "${WAZUH_NODE_TYPE}" != "master" ] && exclude_pattern="${exclude_pattern}|apid"
+    if [ "$(${WAZUH_MANAGER_CONF} get auth.disabled 2>/dev/null)" = "true" ]; then
+        exclude_pattern="${exclude_pattern}|authd"
+    fi
+
+    /var/wazuh-manager/bin/wazuh-manager-control status 2>/dev/null \
+        | grep -vE "${exclude_pattern}" \
+        | grep -qE 'not running|failed to start|refused its configuration'
+}
+
+sleep "${STARTUP_GRACE_PERIOD}"
+while kill -0 "${TAIL_PID}" 2>/dev/null; do
+    if _manager_unhealthy; then
+        echo "Wazuh Manager is not running as expected, exiting so the container can be restarted..."
+        _stop 1
+    fi
+    sleep "${CHECK_INTERVAL}" &
+    wait $!
+done
 
 wait "${TAIL_PID}"


### PR DESCRIPTION
## Summary

`wazuh-manager-control` starts all 8 manager daemons once and the entrypoint's `tail -F & wait` never checks whether any of them are still alive. If one dies (e.g. `apid`'s master killed by OOM or a signal, see #2626), the container stays `Up` forever with a dead API, and `restart: always` never gets a chance to react because nothing ever exits.

## Changes

Added a supervision loop to the manager's `entrypoint.sh`: every 15s (after a 60s grace period matching the healthcheck's own `start_period`), it checks `wazuh-manager-control status`'s own exit code — same failure vocabulary as the compose healthcheck fixed in #2642 (`not running` / `failed to start` / `refused its configuration`) — and exits non-zero if a critical daemon is down, so the container actually stops and the existing `restart: always` policy brings it back.

Two exclusions were needed because `wazuh-manager-control`'s `status()` doesn't apply them itself:
- `apid` on worker nodes (it never runs there — same exclusion the multi-node worker healthcheck already applies).
- `authd` when `auth.disabled: true` is set (`start_service()` skips starting it in that case, but `status()` has no matching exclusion — a real bug in the core script found while testing this fix; without compensating here, any deployment with `auth.disabled: true` would restart-loop forever).

## Verification

Reproduced live against the published image (`public.ecr.aws/wazuh-cicd/wazuh/wazuh-manager:5.0.0-latest`), mounting the modified entrypoint over it:

- **Baseline repro**: killed the `apid` master process directly (`kill -9` on the pid with `ppid=1`). Confirmed the container previously stayed `Up` indefinitely; with this fix, it exits ~60-70s later with `"Wazuh Manager is not running as expected, exiting so the container can be restarted..."`, and with `--restart=always`, `RestartCount` climbs 0→1→2→3 in ~70s cycles instead of staying at 0.
- **`auth.disabled: true` case**: set `<disabled>yes</disabled>` in `wazuh-manager.conf`, confirmed `authd` correctly doesn't start but `wazuh-manager-control status` still reports it `not running` (the core bug). Confirmed the exclusion neutralizes this specific false positive.
- **Negative control**: with `auth.disabled: false`, killing `authd` for real is still correctly detected as unhealthy (the exclusion isn't masking real failures).
- `shellcheck` (style level) on the modified script: clean, no findings.

## Related

- #2627 / #2642: same failure vocabulary, same file area. This loop is the piece that makes the (now correct) healthcheck's `unhealthy` status actually result in an action — under plain `docker compose`, nothing else consumes that status.
- Confirmed this isn't a Docker-vs-others gap: `wazuh-kubernetes` already has equivalent liveness probes (#1578) that do restart the pod on the same failure signal — this PR is Docker reaching parity with what Kubernetes already does, not a new workaround.