### PR TITLE
fix: append opensearch_security.cookie.ttl when missing, drop 13 unsupported dashboard env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#2629](https://github.com/wazuh/wazuh-docker/issues/2629) | Append `opensearch_security.cookie.ttl` when missing from `opensearch_dashboards.yml` instead of silently discarding `OPENSEARCH_SECURITY_COOKIE_TTL`; removed the `PATTERN`, `CHECKS_*`, `APP_TIMEOUT`, `API_SELECTOR`, `IP_SELECTOR`, `IP_IGNORE` and `WAZUH_MONITORING_*` environment variables, which no longer correspond to any setting the dashboard plugin accepts |
 
 ## Prior versions
 

--- a/build-docker-images/wazuh-dashboard/Dockerfile
+++ b/build-docker-images/wazuh-dashboard/Dockerfile
@@ -62,20 +62,7 @@ ARG WAZUH_GID=101
 ENV USER="wazuh-dashboard" \
     GROUP="wazuh-dashboard" \
     NAME="wazuh-dashboard" \
-    INSTALL_DIR="/usr/share/wazuh-dashboard" \
-    PATTERN="" \
-    CHECKS_PATTERN="" \
-    CHECKS_TEMPLATE="" \
-    CHECKS_API="" \
-    CHECKS_SETUP="" \
-    APP_TIMEOUT="" \
-    API_SELECTOR="" \
-    IP_SELECTOR="" \
-    IP_IGNORE="" \
-    WAZUH_MONITORING_ENABLED="" \
-    WAZUH_MONITORING_FREQUENCY="" \
-    WAZUH_MONITORING_SHARDS="" \
-    WAZUH_MONITORING_REPLICAS=""
+    INSTALL_DIR="/usr/share/wazuh-dashboard"
 
 # Copy and set permissions to scripts
 COPY config/entrypoint.sh /

--- a/build-docker-images/wazuh-dashboard/config/wazuh_dashboard_config.sh
+++ b/build-docker-images/wazuh-dashboard/config/wazuh_dashboard_config.sh
@@ -27,21 +27,6 @@ API_USERNAME="${API_USERNAME:-wazuh-wui}"
 API_PASSWORD="${API_PASSWORD:-wazuh-wui}"
 RUN_AS="${RUN_AS:-true}"
 
-# Optional Wazuh app configurations
-PATTERN="${PATTERN:-}"
-CHECKS_PATTERN="${CHECKS_PATTERN:-}"
-CHECKS_TEMPLATE="${CHECKS_TEMPLATE:-}"
-CHECKS_API="${CHECKS_API:-}"
-CHECKS_SETUP="${CHECKS_SETUP:-}"
-APP_TIMEOUT="${APP_TIMEOUT:-}"
-API_SELECTOR="${API_SELECTOR:-}"
-IP_SELECTOR="${IP_SELECTOR:-}"
-IP_IGNORE="${IP_IGNORE:-}"
-WAZUH_MONITORING_ENABLED="${WAZUH_MONITORING_ENABLED:-}"
-WAZUH_MONITORING_FREQUENCY="${WAZUH_MONITORING_FREQUENCY:-}"
-WAZUH_MONITORING_SHARDS="${WAZUH_MONITORING_SHARDS:-}"
-WAZUH_MONITORING_REPLICAS="${WAZUH_MONITORING_REPLICAS:-}"
-
 # Configuration file path
 DASHBOARD_CONFIG_FILE="${DASHBOARD_CONFIG_FILE:-/usr/share/wazuh-dashboard/config/opensearch_dashboards.yml}"
 
@@ -64,19 +49,6 @@ declare -A CONFIG_MAP=(
     [opensearch_security.cookie.ttl]="$OPENSEARCH_SECURITY_COOKIE_TTL"
     [opensearch_security.session.ttl]="$OPENSEARCH_SECURITY_SESSION_TTL"
     [opensearch_security.session.keepalive]="$OPENSEARCH_SECURITY_SESSION_KEEPALIVE"
-    [pattern]="$PATTERN"
-    [checks.pattern]="$CHECKS_PATTERN"
-    [checks.template]="$CHECKS_TEMPLATE"
-    [checks.api]="$CHECKS_API"
-    [checks.setup]="$CHECKS_SETUP"
-    [timeout]="$APP_TIMEOUT"
-    [api.selector]="$API_SELECTOR"
-    [ip.selector]="$IP_SELECTOR"
-    [ip.ignore]="$IP_IGNORE"
-    [wazuh.monitoring.enabled]="$WAZUH_MONITORING_ENABLED"
-    [wazuh.monitoring.frequency]="$WAZUH_MONITORING_FREQUENCY"
-    [wazuh.monitoring.shards]="$WAZUH_MONITORING_SHARDS"
-    [wazuh.monitoring.replicas]="$WAZUH_MONITORING_REPLICAS"
 )
 
 # Replace configuration values in the dashboard config file
@@ -91,9 +63,17 @@ for key in "${!CONFIG_MAP[@]}"; do
     # Escape special characters for sed
     escaped_key=$(echo "$key" | sed 's/[.[\*^$()+?{|]/\\&/g')
 
-    # Try to replace existing line (commented or uncommented)
+    # Try to replace existing line (commented or uncommented); if the key is
+    # not present at all, append it instead of dropping the value silently.
     if grep -q "^[#[:space:]]*${escaped_key}:" "$DASHBOARD_CONFIG_FILE"; then
         sed -i "s|^[#[:space:]]*${escaped_key}:.*|${key}: ${value}|" "$DASHBOARD_CONFIG_FILE"
+    else
+        # Ensure the file ends in a newline before appending, otherwise the
+        # new line would be glued onto the previous one.
+        if [ -s "$DASHBOARD_CONFIG_FILE" ] && [ "$(tail -c1 "$DASHBOARD_CONFIG_FILE")" != "" ]; then
+            echo >> "$DASHBOARD_CONFIG_FILE"
+        fi
+        echo "${key}: ${value}" >> "$DASHBOARD_CONFIG_FILE"
     fi
 done
 

--- a/tools/tests/check-dashboard-config-append.sh
+++ b/tools/tests/check-dashboard-config-append.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Wazuh Docker Copyright (C) 2017, Wazuh Inc. (License GPLv2)
+#
+# Regression test for https://github.com/wazuh/wazuh-docker/issues/2629
+#
+# wazuh_dashboard_config.sh only replaced a CONFIG_MAP key when it already
+# existed in opensearch_dashboards.yml, silently discarding OPENSEARCH_SECURITY_COOKIE_TTL
+# (the only currently-supported key missing from the shipped file — the plugin no longer
+# recognizes the other legacy application settings that used to live in CONFIG_MAP, so
+# those were removed instead of being appended; see the issue for the schema evidence).
+# This verifies the key that is genuinely supported now gets appended, without disturbing
+# keys that already exist in the file.
+
+set -euo pipefail
+
+repo_root="${REPO_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+config_script="${repo_root}/build-docker-images/wazuh-dashboard/config/wazuh_dashboard_config.sh"
+test_dir=$(mktemp -d)
+trap 'rm -rf "$test_dir"' EXIT
+
+config_file="${test_dir}/opensearch_dashboards.yml"
+# No trailing newline on purpose, to exercise the append guard.
+printf 'server.host: 0.0.0.0\nserver.port: 443' > "$config_file"
+
+DASHBOARD_CONFIG_FILE="$config_file" \
+SERVER_HOST="127.0.0.1" \
+OPENSEARCH_SECURITY_COOKIE_TTL="123456" \
+"$BASH" "$config_script"
+
+# Existing key must still be replaced in place.
+grep -Fqx "server.host: 127.0.0.1" "$config_file"
+
+# The line preceding the append must be untouched by the newline guard.
+grep -Fqx "server.port: 443" "$config_file"
+
+# The one currently-supported absent key must now be appended, not silently dropped.
+grep -Fqx "opensearch_security.cookie.ttl: 123456" "$config_file"
+
+echo "wazuh_dashboard_config.sh appends opensearch_security.cookie.ttl when absent"


### PR DESCRIPTION
## Summary

Fixes #2629.

`wazuh_dashboard_config.sh` only replaced a `CONFIG_MAP` key when it already existed in `opensearch_dashboards.yml`, silently discarding the value otherwise (exit 0, no log). Fourteen keys were affected — the 13 application settings the Dockerfile advertises via `ENV` (`PATTERN`, `CHECKS_*`, `APP_TIMEOUT`, `API_SELECTOR`, `IP_SELECTOR`, `IP_IGNORE`, `WAZUH_MONITORING_*`) plus `OPENSEARCH_SECURITY_COOKIE_TTL`.

The issue's suggested fix was to append the key when missing. Before merging that as-is, I validated it end-to-end on a real EC2 instance running the full `single-node` stack. **13 of the 14 keys crash the dashboard on startup** once actually applied — the current `wazuh` plugin's config schema (`plugins/wazuh/server/config.js`) only defines `disabledSettings`; it no longer recognizes `pattern`, `checks.*`, `timeout`, `api.selector`, `ip.selector`, `ip.ignore` or `wazuh.monitoring.*`. This is confirmed by the plugin's own [4.x→5.x migration guide](https://github.com/wazuh/wazuh-dashboard-plugins/blob/main/docs/ref/migration-4x-5x.md), which documents these settings as removed in the 5.0 rewrite (some moved to the Advanced Settings UI, others dropped outright).

So this PR does two things:
- Appends `opensearch_security.cookie.ttl` when it's missing (the one key from the original 14 that the plugin still supports), with a newline guard so the appended line never merges into the previous one.
- Removes the 13 obsolete `ENV` declarations from the Dockerfile and their `CONFIG_MAP` entries from the script — they no longer correspond to anything the dashboard plugin accepts, so leaving them was actively misleading.

## Test plan

- [x] Unit-style regression test: `tools/tests/check-dashboard-config-append.sh` — existing key still replaced in place, `opensearch_security.cookie.ttl` appended when absent, newline guard doesn't corrupt the preceding line.
- [x] Full `single-node` stack (indexer + manager + dashboard) on a real EC2 instance, using the published `5.0.0-latest` images: all 3 containers healthy, `opensearch_security.cookie.ttl` applied correctly, no other key affected.
- [x] Baseline comparison against the unpatched image confirms the original silent-discard behavior.

## Notes for reviewers

- Related to #2631 / #2646 (same file, different bug — `sed` metacharacter escaping). No code conflict; #2646 doesn't touch the branch this PR modifies.
- Out of scope: the Appendix in #2629 describes a second, independent bug in the same script (`sed -i` failing with `EBUSY` when the config file is bind-mounted as a single file). Not addressed here.